### PR TITLE
[알림용 pull request입니다, Merge하지 마세요] Fix issue #162 (스크립트 작동 문제)

### DIFF
--- a/apps/review/urls.py
+++ b/apps/review/urls.py
@@ -15,26 +15,26 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.http import HttpResponseRedirect
-
+from . import views
 
 urlpatterns = [
-    url(r'^$', 'apps.review.views.LastCommentView'),
-    url(r'^json/(?P<page>[0-9]+)/$', 'apps.review.views.LastCommentView_json'),
-    url(r'^result/comment/([1-9][0-9]*)/$', 'apps.review.views.ReviewView'),
+    url(r'^$', views.LastCommentView),
+    url(r'^json/(?P<page>[0-9]+)/$', views.LastCommentView_json),
+    url(r'^result/comment/([1-9][0-9]*)/$', views.ReviewView),
     url(r'^result/professor/([1-9][0-9]*)/$', lambda x,y :HttpResponseRedirect('./-1/')),
-    url(r'^result/professor/([1-9][0-9]*)/([^/]+)/$', 'apps.review.views.SearchResultProfessorView'),
-    url(r'^result/professor/([^/]+)/json/([^/]+)/([^/]+)/$', 'apps.review.views.SearchResultProfessorView_json'),
+    url(r'^result/professor/([1-9][0-9]*)/([^/]+)/$', views.SearchResultProfessorView),
+    url(r'^result/professor/([^/]+)/json/([^/]+)/([^/]+)/$', views.SearchResultProfessorView_json),
     url(r'^result/course/([1-9][0-9]*)/$', lambda x,y :HttpResponseRedirect('./-1/')),
-    url(r'^result/course/([1-9][0-9]*)/([^/]+)/$', 'apps.review.views.SearchResultCourseView'),
-    url(r'^result/course/([^/]+)/([^/]+)/json/([^/]+)/$', 'apps.review.views.SearchResultCourseView_json'),
-    url(r'^result/$', 'apps.review.views.SearchResultView', name="search_result_page"),
-    url(r'^result/json/(?P<page>[0-9]+)/$', 'apps.review.views.SearchResultView_json'),
-    url(r'^insert/$', 'apps.review.views.ReviewInsertView'),
-    url(r'^insert/([^/]+)/([^/]+)/add/$', 'apps.review.views.ReviewInsertAdd'),
-    url(r'^insert/([^/]+)/([^/]+)/$', 'apps.review.views.ReviewInsertView'),
-    url(r'^delete/$','apps.review.views.ReviewDelete'),
-    url(r'^like/$','apps.review.views.ReviewLike'),
-    url(r'^refresh/$','apps.review.views.ReviewRefresh'),
-    url(r'^portal/$','apps.review.views.ReviewPortal'),
-    url(r'^dictionary/([^/]+)/$', 'apps.review.views.dictionary'),
+    url(r'^result/course/([1-9][0-9]*)/([^/]+)/$', views.SearchResultCourseView),
+    url(r'^result/course/([^/]+)/([^/]+)/json/([^/]+)/$', views.SearchResultCourseView_json),
+    url(r'^result/$', views.SearchResultView, name="search_result_page"),
+    url(r'^result/json/(?P<page>[0-9]+)/$', views.SearchResultView_json),
+    url(r'^insert/$', views.ReviewInsertView),
+    url(r'^insert/([^/]+)/([^/]+)/add/$', views.ReviewInsertAdd),
+    url(r'^insert/([^/]+)/([^/]+)/$', views.ReviewInsertView),
+    url(r'^delete/$',views.ReviewDelete),
+    url(r'^like/$',views.ReviewLike),
+    url(r'^refresh/$',views.ReviewRefresh),
+    url(r'^portal/$',views.ReviewPortal),
+    url(r'^dictionary/([^/]+)/$', views.dictionary),
 ]

--- a/apps/review/views.py
+++ b/apps/review/views.py
@@ -751,20 +751,16 @@ def LastCommentView_json(request, page=-1):
     return JsonResponse(json.dumps(context),safe=False)
 
 def page_not_found(request):
-    response = render_to_response(
-        'review/404.html',
-        context_instance=RequestContext(request)
-    )
+    response = render(
+        request,'review/404.html')
 
     response.status_code = 404
 
     return response
 
 def server_error(request):
-    response = render_to_response(
-        'review/500.html',
-        context_instance=RequestContext(request)
-    )
+    response = render(
+        request,'review/500.html')
 
     response.status_code = 500
 

--- a/apps/session/urls.py
+++ b/apps/session/urls.py
@@ -17,14 +17,16 @@ from django.conf.urls import include, url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
 
+from . import views
+
 urlpatterns = [
-    url(r'^$', 'apps.session.views.home'),
-    url(r'^login/$', 'apps.session.views.user_login'),
-    url(r'^login/callback/$', 'apps.session.views.login_callback'),
-    url(r'^logout/$', 'apps.session.views.user_logout'),
-    url(r'^unregister/$', 'apps.session.views.unregister'),
-    url(r'^unregister/callback/$', 'apps.session.views.unregister_callback'),
+    url(r'^$', views.home),
+    url(r'^login/$', views.user_login),
+    url(r'^login/callback/$', views.login_callback),
+    url(r'^logout/$', views.user_logout),
+    url(r'^unregister/$', views.unregister),
+    url(r'^unregister/callback/$', views.unregister_callback),
 
     # User Preferences (e.g Favorite Department, Language)
-    url(r'^settings/$', 'apps.session.views.settings'),
+    url(r'^settings/$', views.settings),
 ]

--- a/apps/subject/urls.py
+++ b/apps/subject/urls.py
@@ -16,7 +16,8 @@ Including another URLconf
 from django.conf.urls import include, url
 from django.contrib import admin
 from django.http import HttpResponseRedirect
+from . import views
 
 urlpatterns = [
-    url(r'^$', 'apps.subject.views.home'),
+    url(r'^$', views.home),
 ]

--- a/apps/timetable/urls.py
+++ b/apps/timetable/urls.py
@@ -15,8 +15,8 @@ Including another URLconf
 """
 from django.conf.urls import url
 from django.http import HttpResponseRedirect
-
+from . import views
 
 urlpatterns = [
-    url(r'^$', 'apps.timetable.views.main'),
+    url(r'^$', views.main),
 ]

--- a/db_update_script.sh
+++ b/db_update_script.sh
@@ -3,6 +3,11 @@ echo "Start!"
 echo $(date +'%Y-%m-%d / %T') > db_update_script.log
 
 python manage.py makemigrations >> db_update_script.log
+python manage.py makemigrations review >> db_update_script.log
+python manage.py makemigrations session >> db_update_script.log
+python manage.py makemigrations timetable >> db_update_script.log
+python manage.py makemigrations subject >> db_update_script.log
+python manage.py check >> db_update_script.log
 python manage.py migrate >> db_update_script.log
 python update_scholardb.py >> db_update_script.log
 python manage.py delete-needlessLecture >> db_update_script.log

--- a/otlplus/urls.py
+++ b/otlplus/urls.py
@@ -22,6 +22,12 @@ from django.conf.urls import (
     handler400, handler403, handler404, handler500
 )
 
+from django.conf import settings
+from django.conf.urls.static import static
+
+from apps.review import views as review_views
+from django import views as django_views
+
 handler400 = 'apps.review.views.bad_request'
 handler403 = 'apps.review.views.permission_denied'
 handler404 = 'apps.review.views.page_not_found'
@@ -32,20 +38,18 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
 
     # OTLplus Apps
-    url(r'^main/$', 'apps.review.views.search_view'),
-    url(r'^tutorial_again/$', 'apps.review.views.search_view_first_again'),
-    url(r'^tutorial/$', 'apps.review.views.search_view_first'),
-    url(r'^tutorial2/$', 'apps.review.views.search_view_first2'),
-    url(r'^tutorial3/$', 'apps.review.views.search_view_first3'),
-    url(r'^tutorial4/$', 'apps.review.views.search_view_first4'),
-    url(r'^credits/$', 'apps.review.views.credits'),
-    url(r'^licenses/$', 'apps.review.views.licenses'),
+    url(r'^main/$', review_views.search_view),
+    url(r'^tutorial_again/$', review_views.search_view_first_again),
+    url(r'^tutorial/$', review_views.search_view_first),
+    url(r'^tutorial2/$', review_views.search_view_first2),
+    url(r'^tutorial3/$', review_views.search_view_first3),
+    url(r'^tutorial4/$', review_views.search_view_first4),
+    url(r'^credits/$', review_views.credits),
+    url(r'^licenses/$', review_views.licenses),
     url(r'^$', lambda x: HttpResponseRedirect('/main/')),
     url(r'^session/', include('apps.session.urls')),
     url(r'^review/', include('apps.review.urls')),
     url(r'^subject/', include('apps.subject.urls')),
-    url(r'^timetable/', include('apps.timetable.urls')), 
+    url(r'^timetable/', include('apps.timetable.urls')),
+] + static(r'^media/(?P<path>.*)$', document_root = os.path.join(BASE_DIR, 'static'))
     # Media Root
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-        {'document_root': os.path.join(BASE_DIR, 'static')}),
-]


### PR DESCRIPTION
찾아보니 Django 1.9.7에서는 python manage.py migrate를 하기전에
python manage.py makemigrations를 하고,
python manage.py makemigrations [db와_관련된_app_name]을 해야되는 것으로 바뀌는 것 같습니다.

그러므로 python manage.py migrate를 하기 전에 네 줄을 추가시켜주시면 되는데, 이는 change 부분의 db_update_script.sh를 참고하세요