### PR TITLE
Hotfix unregister

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ db_update_script.sh
 update_taken_lecture_user.py
 update_scholardb.py
 db_update_script.log
+
+# file for atom editor remote ftp plugin. contains confidential(ssh account info)
+.ftpconfig

--- a/apps/session/views.py
+++ b/apps/session/views.py
@@ -63,6 +63,9 @@ def login_callback(request):
     except:
         student_id = ''
 
+    if student_id is None:
+        student_id= ''
+
     if len(user_list) == 0:
         user = User.objects.create_user(username=username,
                     email=sso_profile['email'],

--- a/static/js/components/header.js
+++ b/static/js/components/header.js
@@ -22,9 +22,10 @@ $('.logout').click(function() {
 });
 
 $('#unregister').click(function() {
-    if (confirm("정말로 OTLPLUS에서 탈퇴하시겠습니까?\n\n" +
-            "* SPARCS SSO는 회원 탈퇴 되지 않습니다.\n*" +
-            " 탈퇴 후 60일이 지나야 재가입이 가능합니다.")) {
+    if (confirm("정말로 OTL+ 서비스를 SSO 계정에서 해지하시겠습니까?\n\n" +
+            "* 주의: SPARCS SSO는 회원 탈퇴 되지 않고 그대로 유지됩니다.\n*" +
+            " 재등록을 위해서는 같은 SSO 아이디로 OTL+ 로그인을 시도하시면 됩니다.\n*"+
+            " 탈퇴 후 60일이 지나야 OTL+ 재등록이 가능합니다.")) {
         $.ajax({
             'method' : 'POST',
             'url' : '/session/unregister/',

--- a/templates/session/settings.html
+++ b/templates/session/settings.html
@@ -32,13 +32,13 @@
     <form id="contact" action="" method="post" class="form-inline col-xs-22 col-xs-offset-1 col-sm-20 col-sm-offset-2 col-md-18 col-md-offset-3 col-lg-16 col-lg-offset-4">
         {% csrf_token %}
         <div class="panel-b col-xs-24 expect">
-            <div class="panel-body">  
+            <div class="panel-body">
     <div class="col-xs-24">
         <h3 >언어</h3>
 
     <div class="col-xs-24">
         <label class="radio-inline">
-            <input type="radio" name="language" value="ko" {% if usr_lang  == 'ko' %}checked{% endif %}> 한국어 
+            <input type="radio" name="language" value="ko" {% if usr_lang  == 'ko' %}checked{% endif %}> 한국어
         </label>
         <label class="radio-inline">
             <input type="radio" name="language" value="en" {% if usr_lang  == 'en' %}checked{% endif %}> English
@@ -63,12 +63,12 @@
     </a>
            </div>
         <div style="margin-top: 25px;">
-            <button id="unregister" type="button" class="btn btn-review-delete" style="width: 90px">회원 탈퇴</button>
+            <button id="unregister" type="button" class="btn btn-review-delete" style="width: 90px">OTL+ 해지</button>
             <div class="text-right" style="float:right;">
                 <input type="submit" class="btn btn-review-upload" value="업로드">
             </div>
         </div>
- 
+
   </form>
 {% endblock %}
 


### PR DESCRIPTION
이메일로 오티엘 플러스 회원 가입 후 internal server error가 발생하며 로그인이 불가능하다는 제보가 왔었습니다.
상황을 재현하기 위해서 테스트 서비스 상에서 테스트 계정을 만들고 회원 탈퇴를 해보기로 했는데,
로그인부터 internal server error가 발생하며 실패했습니다. 
이 오류는 포탈 연동 없이 가입을 했을 때 학번을 불러오지 못해서 생긴 오류로 학번을 불러오지 못할 경우에
exception이 발생할 거라 생각하여 try-except 블록으로 예외 처리를 했었는데,
실제로는 예외가 발생하지 않고 그냥 학번이 None으로 리턴되어 나와서 integrity error가 발생했었던 거였습니다.

그 오류를 해결하면서 생각한 것이,
이메일을 보낸 회원도 otl+를 재등록하는 것이 아닌 sso 아이디를 새로 만들어서 접속을 시도해서가 아닌가 였습니다.
OTL+ 회원탈퇴와 sso 회원 탈퇴는 전혀 무관한데, 유저가 이를 혼동해서 생긴 문제였습니다.
이에 따라, OTL+ 회원 탈퇴 버튼을 OTL+ 해지 버튼으로 변경하고, 버튼을 눌렀을 때의 경고 메시지를 
더 친절하게 고쳤습니다.  