### PR TITLE
README.md 에 개발 환경 설정 중 Troubleshooting 항목 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ $ python manage.py migrate
 ```
 
 ### SPARCS SSO 설정
-SSO 설정 방법은 변경될 수 있습니다. SSO 공식 설정 방법을 참고하세요.  
+SSO 설정 방법은 변경될 수 있습니다. SSO 공식 설정 방법을 참고하세요.
 URL: `sparcssso.kaist.ac.kr > Dev Center > Test Services > Register`
-> Alias: (Any name)  
-> Main URL: http://localhost:8000  
-> Login Callback URL: http://localhost:8000/session/login/callback  
-> Unregister URL: http://localhost:8000/session/unregister  
-> Cooltime: 0  
-> 
+> Alias: (Any name)
+> Main URL: http://localhost:8000
+> Login Callback URL: http://localhost:8000/session/login/callback
+> Unregister URL: http://localhost:8000/session/unregister
+> Cooltime: 0
+>
 Working directory: `PROJECT_ROOT`
 ```shell
 $ vi settings_local.py
@@ -54,7 +54,7 @@ File: `PROJECT_ROOT/settings_local.py`
 # ...
 
 SSO_IS_BETA = False
-SSO_CLIENT_ID = "test0000000000000000" # SSO의 'Name' 필드
+SSO_CLIENT_ID = "test0000000000000000" # SSO의 'Name' (또는 'Client ID') 필드
 SSO_SECRET_KEY = "00000000000000000000" # SSO의 'Secret Key' 필드
 ```
 
@@ -64,12 +64,26 @@ Working directory: `PROJECT_ROOT/react`
 # 패키지 설치
 $ npm install
 
+# 개발 서버 실행
+$ npm start
+
 # 프로젝트 빌드
 $ npm run build
 ```
+
+#### node-sass 설치 시 오류가 발생한다면
+1. [node-sass 호환 node.js 버전](https://github.com/sass/node-sass#node-version-support-policy)을 확인해서 적절한 버전을 사용
+2. `gyp: No Xcode or CLT version detected!` 라는 메시지와 함께 설치에 실패한다면 [관련 이슈](https://github.com/schnerd/d3-scale-cluster/issues/7)의 코멘트 참고
 
 ### 서버 실행
 Working directory: `PROJECT_ROOT`
 ```shell
 $ python manage.py runserver 0.0.0.0:8000
+```
+
+#### mysqlclient 설치 시 오류가 발생한다면
+mysql@5.7 ([5.7 버전이어야 하는 이유](https://stackoverflow.com/a/50342229)) 을 설치 후 PATH에 해당 실행 파일 디렉터리를 추가한다. 예를 들면 (macOS 기준),
+```shell
+$ brew install mysql@5.7
+$ export PATH="/opt/homebrew/opt/mysql@5.7/bin:$PATH" # add this line to ~/.bashrc, .zshrc, etc.
 ```

--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ $ python manage.py migrate
 ```
 
 ### SPARCS SSO 설정
-SSO 설정 방법은 변경될 수 있습니다. SSO 공식 설정 방법을 참고하세요.
+SSO 설정 방법은 변경될 수 있습니다. SSO 공식 설정 방법을 참고하세요.  
 URL: `sparcssso.kaist.ac.kr > Dev Center > Test Services > Register`
-> Alias: (Any name)
-> Main URL: http://localhost:8000
-> Login Callback URL: http://localhost:8000/session/login/callback
-> Unregister URL: http://localhost:8000/session/unregister
-> Cooltime: 0
->
+> Alias: (Any name)  
+> Main URL: http://localhost:8000  
+> Login Callback URL: http://localhost:8000/session/login/callback  
+> Unregister URL: http://localhost:8000/session/unregister  
+> Cooltime: 0  
+> 
 Working directory: `PROJECT_ROOT`
 ```shell
 $ vi settings_local.py

--- a/react/package.json
+++ b/react/package.json
@@ -2,6 +2,9 @@
   "name": "otlplus",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "< 13.0.0"
+  },
   "dependencies": {
     "axios": "^0.20.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
* (사소하지만) 개발 서버 실행 스크립트를 가이드에 추가합니다.
* 장고, 리액트 프로젝트 셋업 중 만났던 오류의 대응 방법을 추가합니다.
* 리액트 프로젝트에 node.js 버전을 12 이하로 제한합니다. node-sass 의 제약으로 14 이하여야 하는 것으로 보이는데, npm 버전이 6을 넘어가면 package-lock.json 의 lockfileVersion 이 올라가서 거대한 diff 가 생기는 문제가 있습니다. (node 버전 올리는 건 별도 작업으로 하는 게 좋아 보여요)