### PR TITLE
Added and applied new component category Tile

### DIFF
--- a/react/src/components/sections/main/TodaysTimetableSection.js
+++ b/react/src/components/sections/main/TodaysTimetableSection.js
@@ -8,7 +8,7 @@ import { range } from 'lodash';
 
 import { appBoundClassNames as classNames } from '../../../common/boundClassNames';
 
-import HorizontalTimetableBlock from '../../blocks/HorizontalTimetableBlock';
+import HorizontalTimetableTile from '../../tiles/HorizontalTimetableTile';
 
 import userShape from '../../../shapes/UserShape';
 import semesterShape from '../../../shapes/SemesterShape';
@@ -113,7 +113,7 @@ class TodaysTimetableSection extends Component {
               l.classtimes
                 .filter((ct) => (ct.day === day - 1))
                 .map((ct) => (
-                  <HorizontalTimetableBlock
+                  <HorizontalTimetableTile
                     key={`${l.id}:${ct.day}:${ct.begin}`}
                     lecture={l}
                     classtime={ct}

--- a/react/src/components/sections/timetable/TimetableSubSection.js
+++ b/react/src/components/sections/timetable/TimetableSubSection.js
@@ -6,7 +6,7 @@ import { range } from 'lodash';
 
 import { appBoundClassNames as classNames } from '../../../common/boundClassNames';
 
-import TimetableBlock from '../../blocks/TimetableBlock';
+import TimetableTile from '../../tiles/TimetableTile';
 
 import { setLectureFocus, clearLectureFocus } from '../../../actions/timetable/lectureFocus';
 import { setSelectedListCode, setMobileIsLectureListOpen } from '../../../actions/timetable/list';
@@ -265,7 +265,7 @@ class TimetableSubSection extends Component {
         untimedBlockTitles.push(title);
       }
       return (
-        <TimetableBlock
+        <TimetableTile
           key={classtime ? `${lecture.id}:${classtime.day}:${classtime.begin}` : `${lecture.id}:no-time`}
           lecture={lecture}
           classtime={classtime}

--- a/react/src/components/sections/timetable/TimetableSubSection.js
+++ b/react/src/components/sections/timetable/TimetableSubSection.js
@@ -195,7 +195,7 @@ class TimetableSubSection extends Component {
     setSelectedListCodeDispatch(SEARCH);
   }
 
-  blockHover = (lecture) => () => {
+  tileHover = (lecture) => () => {
     const { lectureFocus, isDragging, setLectureFocusDispatch } = this.props;
 
     if (!lectureFocus.clicked && !isDragging) {
@@ -203,7 +203,7 @@ class TimetableSubSection extends Component {
     }
   }
 
-  blockOut = () => {
+  tileOut = () => {
     const { lectureFocus, clearLectureFocusDispatch } = this.props;
 
     if (!lectureFocus.clicked) {
@@ -211,7 +211,7 @@ class TimetableSubSection extends Component {
     }
   }
 
-  blockClick = (lecture) => () => {
+  tileClick = (lecture) => () => {
     const { lectureFocus, setLectureFocusDispatch } = this.props;
 
     if (isTableClicked(lecture, lectureFocus)) {
@@ -254,15 +254,15 @@ class TimetableSubSection extends Component {
     const isOutsideTable = (classtime) => (
       classtime.day < 0 || classtime.day > 4 || classtime.begin < 60 * 8 || classtime.end > 60 * 24
     );
-    const untimedBlockTitles = [];
-    const mapClasstimeToBlock = (lecture, classtime, isTemp) => {
+    const untimedTileTitles = [];
+    const mapClasstimeToTile = (lecture, classtime, isTemp) => {
       const isUntimed = !classtime || isOutsideTable(classtime);
       if (isUntimed) {
         const title = classtime
           ? `${[t('ui.day.saturdayShort'), t('ui.day.sundayShort')][classtime.day - 5]} ${getTimeString(classtime.begin)}~${getTimeString(classtime.end)}`
           : t('ui.others.timeNone');
         // eslint-disable-next-line fp/no-mutating-methods
-        untimedBlockTitles.push(title);
+        untimedTileTitles.push(title);
       }
       return (
         <TimetableTile
@@ -270,13 +270,13 @@ class TimetableSubSection extends Component {
           lecture={lecture}
           classtime={classtime}
           dayIndex={isUntimed
-            ? ((untimedBlockTitles.length - 1) % 5)
+            ? ((untimedTileTitles.length - 1) % 5)
             : classtime.day}
           beginIndex={isUntimed
-            ? (32 + Math.floor((untimedBlockTitles.length - 1) / 5))
+            ? (32 + Math.floor((untimedTileTitles.length - 1) / 5))
             : (classtime.begin / 30 - 16)}
           endIndex={isUntimed
-            ? (32 + Math.floor((untimedBlockTitles.length - 1) / 5) + 3)
+            ? (32 + Math.floor((untimedTileTitles.length - 1) / 5) + 3)
             : (classtime.end / 30 - 16)}
           cellWidth={cellWidth}
           cellHeight={cellHeight}
@@ -286,9 +286,9 @@ class TimetableSubSection extends Component {
           isDimmed={isDimmedTableLecture(lecture, lectureFocus)}
           isTemp={isTemp}
           isSimple={mobileIsLectureListOpen}
-          blockHover={isTemp ? null : this.blockHover}
-          blockOut={isTemp ? null : this.blockOut}
-          blockClick={isTemp ? null : this.blockClick}
+          tileHover={isTemp ? null : this.tileHover}
+          tileOut={isTemp ? null : this.tileOut}
+          tileClick={isTemp ? null : this.tileClick}
           deleteLecture={this.deleteLecture}
           occupiedTimes={(isTemp && !isUntimed)
             ? this._getOccupiedTimes(classtime.day, this.indexOfMinute(classtime.begin), this.indexOfMinute(classtime.end))
@@ -296,14 +296,14 @@ class TimetableSubSection extends Component {
         />
       );
     };
-    const mapLectureToBlocks = (lecture, isTemp) => (
+    const mapLectureToTiles = (lecture, isTemp) => (
       lecture.classtimes.length === 0
-        ? mapClasstimeToBlock(lecture, null, isTemp)
-        : lecture.classtimes.map((ct) => mapClasstimeToBlock(lecture, ct, isTemp))
+        ? mapClasstimeToTile(lecture, null, isTemp)
+        : lecture.classtimes.map((ct) => mapClasstimeToTile(lecture, ct, isTemp))
     );
-    const timetableLectureBlocks = timetableLectures.map((lecture) => mapLectureToBlocks(lecture, false));
-    const tempLectureBlocks = tempLecture
-      ? mapLectureToBlocks(tempLecture, true)
+    const timetableLectureTiles = timetableLectures.map((lecture) => mapLectureToTiles(lecture, false));
+    const tempLectureTiles = tempLecture
+      ? mapLectureToTiles(tempLecture, true)
       : null;
 
     const targetMinutes = range(8 * 60, 24 * 60, 30);
@@ -318,7 +318,7 @@ class TimetableSubSection extends Component {
         }
         return <div key={i2} />;
       });
-      const untimedArea = range(Math.ceil(untimedBlockTitles.length / 5)).map((_, i) => (
+      const untimedArea = range(Math.ceil(untimedTileTitles.length / 5)).map((_, i) => (
         <React.Fragment key={_}>
           <div />
           <div className={classNames('table-head')} />
@@ -356,10 +356,10 @@ class TimetableSubSection extends Component {
           />
         );
       });
-      const untimedArea = range(Math.ceil(untimedBlockTitles.length / 5)).map((_, i) => (
+      const untimedArea = range(Math.ceil(untimedTileTitles.length / 5)).map((_, i) => (
         <React.Fragment key={_}>
           <div className={classNames('cell')} />
-          <div className={classNames('table-head')}>{untimedBlockTitles[i * 5 + dayIdx]}</div>
+          <div className={classNames('table-head')}>{untimedTileTitles[i * 5 + dayIdx]}</div>
           <div className={classNames('cell', 'cell-top')} />
           <div className={classNames('cell', 'cell-bottom', (mobileIsLectureListOpen ? 'cell-bottom--mobile-noline' : ''))} />
           <div className={classNames('cell', 'cell-bottom', 'cell-last', (mobileIsLectureListOpen ? 'cell-bottom--mobile-noline' : ''))} />
@@ -409,8 +409,8 @@ class TimetableSubSection extends Component {
           </div>
         </div>
         {dragCell}
-        {timetableLectureBlocks}
-        {tempLectureBlocks}
+        {timetableLectureTiles}
+        {tempLectureTiles}
       </div>
     );
   }

--- a/react/src/components/tiles/HorizontalTimetableTile.js
+++ b/react/src/components/tiles/HorizontalTimetableTile.js
@@ -9,7 +9,7 @@ import lectureShape from '../../shapes/LectureShape';
 import classtimeShape from '../../shapes/ClasstimeShape';
 
 
-const HorizontalTimetableBlock = ({
+const HorizontalTimetableTile = ({
   t,
   lecture, classtime,
   cellWidth, cellHeight,
@@ -41,11 +41,11 @@ const HorizontalTimetableBlock = ({
   );
 };
 
-HorizontalTimetableBlock.propTypes = {
+HorizontalTimetableTile.propTypes = {
   lecture: lectureShape.isRequired,
   classtime: classtimeShape,
   cellWidth: PropTypes.number.isRequired,
   cellHeight: PropTypes.number.isRequired,
 };
 
-export default withTranslation()(React.memo(HorizontalTimetableBlock));
+export default withTranslation()(React.memo(HorizontalTimetableTile));

--- a/react/src/components/tiles/HorizontalTimetableTile.js
+++ b/react/src/components/tiles/HorizontalTimetableTile.js
@@ -18,7 +18,7 @@ const HorizontalTimetableTile = ({
 
   return (
     <div
-      className={classNames('block--horizonatal-timetable', `background-color--${getColorNumber(lecture)}`)}
+      className={classNames('tile--horizonatal-timetable', `background-color--${getColorNumber(lecture)}`)}
       style={{
         left: cellWidth * indexOfTime(classtime.begin) + 2 + 2,
         top: 11 + 4 + 3,
@@ -26,14 +26,14 @@ const HorizontalTimetableTile = ({
         height: cellHeight,
       }}
     >
-      <div className={classNames('block--horizonatal-timetable__content')}>
-        <p className={classNames('block--horizonatal-timetable__content__title')}>
+      <div className={classNames('tile--horizonatal-timetable__content')}>
+        <p className={classNames('tile--horizonatal-timetable__content__title')}>
           {lecture[t('js.property.title')]}
         </p>
-        <p className={classNames('block--horizonatal-timetable__content__info')}>
+        <p className={classNames('tile--horizonatal-timetable__content__info')}>
           {getProfessorsShortStr(lecture)}
         </p>
-        <p className={classNames('block--horizonatal-timetable__content__info')}>
+        <p className={classNames('tile--horizonatal-timetable__content__info')}>
           {classtime[t('js.property.classroom')]}
         </p>
       </div>

--- a/react/src/components/tiles/TimetableTile.js
+++ b/react/src/components/tiles/TimetableTile.js
@@ -9,7 +9,7 @@ import lectureShape from '../../shapes/LectureShape';
 import classtimeShape from '../../shapes/ClasstimeShape';
 
 
-const TimetableBlock = ({
+const TimetableTile = ({
   t,
   lecture, classtime,
   dayIndex, beginIndex, endIndex,
@@ -84,7 +84,7 @@ const TimetableBlock = ({
   );
 };
 
-TimetableBlock.propTypes = {
+TimetableTile.propTypes = {
   lecture: lectureShape.isRequired,
   classtime: classtimeShape,
   dayIndex: PropTypes.number.isRequired,
@@ -105,4 +105,4 @@ TimetableBlock.propTypes = {
   occupiedTimes: PropTypes.arrayOf(PropTypes.array),
 };
 
-export default withTranslation()(React.memo(TimetableBlock));
+export default withTranslation()(React.memo(TimetableTile));

--- a/react/src/components/tiles/TimetableTile.js
+++ b/react/src/components/tiles/TimetableTile.js
@@ -15,7 +15,7 @@ const TimetableTile = ({
   dayIndex, beginIndex, endIndex,
   cellWidth, cellHeight,
   isTimetableReadonly, isRaised, isHighlighted, isDimmed, isTemp, isSimple,
-  blockHover, blockOut, blockClick, deleteLecture,
+  tileHover, tileOut, tileClick, deleteLecture,
   occupiedTimes,
 }) => {
   const onDeleteFromTableClick = (event) => {
@@ -44,9 +44,9 @@ const TimetableTile = ({
         width: cellWidth + 2,
         height: cellHeight * (endIndex - beginIndex) - 3,
       }}
-      onMouseOver={blockHover ? blockHover(lecture) : null}
-      onMouseOut={blockOut}
-      onClick={blockClick ? blockClick(lecture) : null}
+      onMouseOver={tileHover ? tileHover(lecture) : null}
+      onMouseOut={tileOut}
+      onClick={tileClick ? tileClick(lecture) : null}
     >
       { !isTemp && !isTimetableReadonly
         ? <button className={classNames('tile--timetable__button')} onClick={onDeleteFromTableClick}><i className={classNames('icon', 'icon--delete-lecture')} /></button>
@@ -98,9 +98,9 @@ TimetableTile.propTypes = {
   isDimmed: PropTypes.bool.isRequired,
   isTemp: PropTypes.bool.isRequired,
   isSimple: PropTypes.bool.isRequired,
-  blockHover: PropTypes.func,
-  blockOut: PropTypes.func,
-  blockClick: PropTypes.func,
+  tileHover: PropTypes.func,
+  tileOut: PropTypes.func,
+  tileClick: PropTypes.func,
   deleteLecture: PropTypes.func.isRequired,
   occupiedTimes: PropTypes.arrayOf(PropTypes.array),
 };

--- a/react/src/components/tiles/TimetableTile.js
+++ b/react/src/components/tiles/TimetableTile.js
@@ -26,13 +26,13 @@ const TimetableTile = ({
   return (
     <div
       className={classNames(
-        'block',
-        'block--timetable',
+        'tile',
+        'tile--timetable',
         `background-color--${getColorNumber(lecture) + 1}`,
-        (isRaised ? 'block--raised' : ''),
-        (isTemp ? 'block--temp' : ''),
-        (isHighlighted ? 'block--highlighted' : ''),
-        (isDimmed ? 'block--dimmed' : ''),
+        (isRaised ? 'tile--raised' : ''),
+        (isTemp ? 'tile--temp' : ''),
+        (isHighlighted ? 'tile--highlighted' : ''),
+        (isDimmed ? 'tile--dimmed' : ''),
       )}
       style={{
         left: (cellWidth + 5) * dayIndex + 17,
@@ -49,20 +49,20 @@ const TimetableTile = ({
       onClick={blockClick ? blockClick(lecture) : null}
     >
       { !isTemp && !isTimetableReadonly
-        ? <button className={classNames('block--timetable__button')} onClick={onDeleteFromTableClick}><i className={classNames('icon', 'icon--delete-lecture')} /></button>
+        ? <button className={classNames('tile--timetable__button')} onClick={onDeleteFromTableClick}><i className={classNames('icon', 'icon--delete-lecture')} /></button>
         : null
       }
       <div
         // onMouseDown={() => onMouseDown()}
-        className={classNames('block--timetable__content')}
+        className={classNames('tile--timetable__content')}
       >
-        <p className={classNames('block--timetable__content__title', (isSimple ? 'mobile-hidden' : ''))}>
+        <p className={classNames('tile--timetable__content__title', (isSimple ? 'mobile-hidden' : ''))}>
           {lecture[t('js.property.title')]}
         </p>
-        <p className={classNames('block--timetable__content__info', 'mobile-hidden')}>
+        <p className={classNames('tile--timetable__content__info', 'mobile-hidden')}>
           {getProfessorsShortStr(lecture)}
         </p>
-        <p className={classNames('block--timetable__content__info', 'mobile-hidden')}>
+        <p className={classNames('tile--timetable__content__info', 'mobile-hidden')}>
           {classtime ? classtime[t('js.property.classroom')] : null}
         </p>
       </div>
@@ -72,7 +72,7 @@ const TimetableTile = ({
           : occupiedTimes.map((o) => (
             <div
               key={`${o[0]}:${o[1]}`}
-              className={classNames('block--timetable__occupied-area')}
+              className={classNames('tile--timetable__occupied-area')}
               style={{
                 top: cellHeight * o[0],
                 height: cellHeight * (o[1] - o[0]) - 3,

--- a/react/src/styles/App.module.scss
+++ b/react/src/styles/App.module.scss
@@ -1947,28 +1947,28 @@ a {
     overflow: hidden;
     font-size: $font-size-small;
     line-height: $line-height-small;
+    &.tile--highlighted {
+        background-color: #E0546F;
+    }
+    &.tile--raised {
+        margin-top: -3px;
+        margin-bottom: 3px;
+        box-shadow: 0 6px 3px -3px $color-block-shadow-highlight;
+    }
+    &.tile--temp {
+        background-color: #E0546F;
+        opacity: 0.85;
+        z-index: 3;
+        cursor: initial;
+    }
+    &.tile--dimmed {
+        opacity: 0.5;
+        cursor: initial;
+    }
     
 
     &--timetable {
         cursor: pointer;
-        &.tile--highlighted {
-            background-color: #E0546F;
-        }
-        &.tile--raised {
-            margin-top: -3px;
-            margin-bottom: 3px;
-            box-shadow: 0 6px 3px -3px $color-block-shadow-highlight;
-        }
-        &.tile--temp {
-            background-color: #E0546F;
-            opacity: 0.85;
-            z-index: 3;
-            cursor: initial;
-        }
-        &.tile--dimmed {
-            opacity: 0.5;
-            cursor: initial;
-        }
 
         &__button {
             top: 0px;

--- a/react/src/styles/App.module.scss
+++ b/react/src/styles/App.module.scss
@@ -1932,6 +1932,125 @@ a {
 }
 
 
+.tile {
+    position: absolute;
+    flex: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 0px;
+    border-radius: $small-block-border-radius;
+    z-index: 2;
+    top: 1px;
+    left: -1px;
+    width: calc(100% + 2px);
+    overflow: hidden;
+    font-size: $font-size-small;
+    line-height: $line-height-small;
+    
+
+    &--timetable {
+        cursor: pointer;
+        &.tile--highlighted {
+            background-color: #E0546F;
+        }
+        &.tile--raised {
+            margin-top: -3px;
+            margin-bottom: 3px;
+            box-shadow: 0 6px 3px -3px $color-block-shadow-highlight;
+        }
+        &.tile--temp {
+            background-color: #E0546F;
+            opacity: 0.85;
+            z-index: 3;
+            cursor: initial;
+        }
+        &.tile--dimmed {
+            opacity: 0.5;
+            cursor: initial;
+        }
+
+        &__button {
+            top: 0px;
+            right: 0px;
+            position: absolute;
+            cursor: pointer;
+            padding: 4px;
+            background-color: rgba(#E0546F,0.8);
+            .tile--timetable:not(:hover) &,
+            .tile--timetable:not(.tile--highlighted):not(.tile--raised) & {
+                display: none;
+            }
+            @media #{$media-portrait} {
+                display: none;
+            }
+        }
+
+        &__content {
+            padding: 4px 6px;
+            overflow: hidden;
+            max-height: 100%;
+
+            &__title {
+                color: rgba(#000000,0.8);
+                margin: 0;
+                margin-bottom: 1px;
+                pointer-events: none;
+                .tile--timetable.tile--highlighted &,
+                .tile--timetable.tile--raised &,
+                .tile--timetable.tile--temp &
+                 {
+                    color: rgba(#FFFFFF,1);
+                }
+            }
+
+            &__info {
+                color: rgba(#000000,0.5);
+                margin: 0;
+                margin-top: 1px;
+                pointer-events: none;
+                .tile--timetable.tile--highlighted &,
+                .tile--timetable.tile--raised &,
+                .tile--timetable.tile--temp {
+                    color: rgba(#FFFFFF,0.7);
+                }
+            }
+        }
+
+        &__occupied-area { 
+            background-color: #888;
+            position: absolute;
+            left: 0;
+            width: 100%;
+            z-index: -1;
+            border-radius: $small-block-border-radius;
+        }
+    }
+
+    &--horizonatal-timetable {
+        overflow: hidden;
+
+        &__content {
+            padding: 4px 6px;
+            overflow: hidden;
+            max-height: 100%;
+
+            &__title {
+                color: rgba(#000000,0.8);
+                margin: 0;
+                margin-bottom: 1px;
+            }
+
+            &__info {
+                color: rgba(#000000,0.5);
+                margin: 0;
+                margin-top: 1px;
+            }
+        }
+    }
+}
+
+
 .close-button-wrap {
         display: block;
         position: absolute;
@@ -2393,134 +2512,6 @@ a {
                 &__fixed-2 {
                     width: 16px;
                 }
-            }
-        }
-    }
-
-    &--timetable {
-        position: absolute !important;
-        flex: auto;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        padding: 0px;
-        border-radius: $small-block-border-radius;
-        z-index: 2;
-        top: 1px;
-        left: -1px;
-        width: calc(100% + 2px);
-        cursor: pointer;
-        overflow: hidden;
-        &.block--highlighted {
-            background-color: #E0546F;
-        }
-        &.block--raised {
-            margin-top:-3px;
-            margin-bottom:3px;
-            box-shadow: 0 6px 3px -3px $color-block-shadow-highlight;
-        }
-        &.block--temp {
-            background-color: #E0546F;
-            opacity: 0.85;
-            z-index: 3;
-            cursor: initial;
-        }
-
-        &__button {
-            top:0px;
-            right:0px;
-            position:absolute;
-            cursor:pointer;
-            padding:4px;
-            background-color:rgba(#E0546F,0.8);
-            .block--timetable:not(:hover) &,
-            .block--timetable:not(.block--highlighted):not(.block--raised) & {
-                display: none;
-            }
-            @media #{$media-portrait} {
-                display: none;
-            }
-        }
-
-        &__content {
-            padding: 4px 6px;
-            overflow: hidden;
-            max-height: 100%;
-
-            &__title {
-                font-size: $font-size-small;
-                line-height: $line-height-small;
-                color:rgba(#000000,0.8);
-                margin:0;
-                margin-bottom:1px;
-                pointer-events:none;
-                .block--timetable.block--highlighted &,
-                .block--timetable.block--raised &,
-                .block--timetable.block--temp &
-                 {
-                    color:rgba(#FFFFFF,1);
-                }
-            }
-
-            &__info {
-                font-size: $font-size-small;
-                line-height: $line-height-small;
-                color:rgba(#000000,0.5);
-                margin:0;
-                margin-top:1px;
-                pointer-events:none;
-                .block--timetable.block--highlighted &,
-                .block--timetable.block--raised &,
-                .block--timetable.block--temp {
-                    color:rgba(#FFFFFF,0.7);
-                }
-            }
-        }
-
-        &__occupied-area { 
-            background-color: #888;
-            position: absolute;
-            left: 0;
-            width: 100%;
-            z-index: -1;
-            border-radius: $small-block-border-radius;
-        }
-    }
-
-    &--horizonatal-timetable {
-        position: absolute;
-        flex: auto;
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        padding: 0px;
-        border-radius: $small-block-border-radius;
-        z-index: 2;
-        top: 1px;
-        left: -1px;
-        width: calc(100% + 2px);
-        overflow: hidden;
-        white-space: nowrap;
-
-        &__content {
-            padding: 4px 6px;
-            overflow: hidden;
-            max-height: 100%;
-
-            &__title {
-                font-size: $font-size-small;
-                line-height: $line-height-small;
-                color:rgba(#000000,0.8);
-                margin:0;
-                margin-bottom:1px;
-            }
-
-            &__info {
-                font-size: $font-size-small;
-                line-height: $line-height-small;
-                color:rgba(#000000,0.5);
-                margin:0;
-                margin-top:1px;
             }
         }
     }


### PR DESCRIPTION
기존 Block과 Tile을 Block으로 혼용하던 것을 다음의 이유로 분리하고자 합니다.
- Block은 OTL에서 흔히 사용하는 회색 블록을 의미합니다. Tile은 시간표(메인 페이지의 미리보기 포함)의 시간표 타일을 포함해 추후 서비스에서도 추가될 수 있는 색이 있는 타일을 의미합니다.
- Block과 Tile은 외관적, 기능적, 개념적 차이가 있음에도 기존에 Block으로 묶여 있었습니다.
    - Block은 회색인 반면 Tile은 다양한 색을 가집니다.
    - Block과 Tile은 border-radius, padding, font-size 등이 다릅니다.
    - Block은 (거의 대부분) content에 맞는 크기를 가지지만 Tile은 그 속성(시간 등)에 따라 크기가 변화합니다.
    - Block은 (거의 대부분) 위에서 아래로 차례대로 배열되지만 Tile은 그 속성(시간 등)에 따라 위치가 변화합니다.
    - Block은 사용자 행동의 trigger로 주로 사용되지만 Tile은 사용자 행동의 결과물로 주로 사용됩니다.
    - Block은 그 안의 내용물이 주요 정보이지만 Tile은 그 크기와 색상, 위치가 주요 정보입니다.
- 이로 인해 개발자에게 혼동을 줄 수 있을 뿐만 아니라, Block에서 정의된 property를 Tile에 해당하는 subclass에서 거의 모두 재정의해야 했습니다.