### PR TITLE
Fixed scholardb import

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ python3 -m venv env # Python 버전 3.9 이상 권장
 $ source env/bin/activate
 
 # 패키지 설치
-$ pip install -r requirements.txt
+$ pip install -r requirements.txt # unixodbc, mysql@5.7 등을 먼저 설치해야 할 수 있음 (apt, brew 등으로 설치)
 
 # Secret key 설정
 $ mkdir keys

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -231,11 +231,11 @@ class Command(BaseCommand):
                     for i in match_scholar:
                         try:
                             prof_id = i[5]
-                            prof_name = str(i[6], "cp949")
+                            prof_name = str(i[6], "cp949") if isinstance(i[6], bytes) else i[6]
                             if i[8] is None or i[8] == "":
                                 prof_name_en = ""
                             else:
-                                prof_name_en = str(i[8].strip(), "cp949")
+                                prof_name_en = str(i[8].strip(), "cp949") if isinstance(i[8], bytes) else i[8].strip()
                             if i[4] is None or i[4] == "":
                                 prof_major = ""
                             else:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -41,7 +41,7 @@ class Command(BaseCommand):
         port = options.get("port", None)
         user = options.get("user", None)
         password = options.get("password", None)
-        encoding = options.get("encoding", "cp949")
+        encoding = options.get("encoding")
         exclude_lecture = options.get("exclude_lecture", False)
         lecture_count = 0
 
@@ -94,7 +94,7 @@ class Command(BaseCommand):
             for row in rows:
                 myrow = []
                 for elem in row:
-                    if isinstance(elem, str):
+                    if isinstance(elem, bytes):
                         try:
                             elem = elem.decode(encoding)
                         except UnicodeDecodeError:
@@ -287,7 +287,7 @@ class Command(BaseCommand):
             print(row)
             myrow = []
             for elem in row:
-                if isinstance(elem, str):
+                if isinstance(elem, bytes):
                     try:
                         elem = elem.decode(encoding)
                     except UnicodeDecodeError:
@@ -324,7 +324,7 @@ class Command(BaseCommand):
             print(row)
             myrow = []
             for elem in row:
-                if isinstance(elem, str):
+                if isinstance(elem, bytes):
                     try:
                         elem = elem.decode(encoding)
                     except UnicodeDecodeError:
@@ -370,7 +370,7 @@ class Command(BaseCommand):
         for row in syllabuses:
             myrow = []
             for elem in row:
-                if isinstance(elem, str):
+                if isinstance(elem, bytes):
                     try:
                         elem = elem.decode(encoding)
                     except UnicodeDecodeError:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -92,16 +92,7 @@ class Command(BaseCommand):
 
             prev_department = None
             for row in rows:
-                myrow = []
-                for elem in row:
-                    if isinstance(elem, bytes):
-                        try:
-                            elem = elem.decode(encoding)
-                        except UnicodeDecodeError:
-                            elem = "%s (???)" % row[20]
-                            print(f"ERROR: parsing error on lecture {row[20]}", file=sys.stderr)
-                            print(f'       cannot read "{elem}" in cp949.', file=sys.stderr)
-                    myrow.append(elem)
+                myrow = row[:]
 
                 # Extract department info.
                 lecture_no = myrow[2]
@@ -231,11 +222,11 @@ class Command(BaseCommand):
                     for i in match_scholar:
                         try:
                             prof_id = i[5]
-                            prof_name = str(i[6], "cp949") if isinstance(i[6], bytes) else i[6]
+                            prof_name = i[6]
                             if i[8] is None or i[8] == "":
                                 prof_name_en = ""
                             else:
-                                prof_name_en = str(i[8].strip(), "cp949") if isinstance(i[8], bytes) else i[8].strip()
+                                prof_name_en = i[8].strip()
                             if i[4] is None or i[4] == "":
                                 prof_major = ""
                             else:
@@ -287,15 +278,7 @@ class Command(BaseCommand):
         ExamTime.objects.filter(lecture__year__exact=next_year, lecture__semester=next_semester).delete()
         for row in exam_times:
             print(row)
-            myrow = []
-            for elem in row:
-                if isinstance(elem, bytes):
-                    try:
-                        elem = elem.decode(encoding)
-                    except UnicodeDecodeError:
-                        elem = "???"
-                        print("ERROR: parsing error on lecture. cannot read in cp949.", file=sys.stderr)
-                myrow.append(elem)
+            myrow = row[:]
             lecture_key = {
                 "deleted": False,
                 "code": myrow[2],
@@ -324,15 +307,7 @@ class Command(BaseCommand):
         ClassTime.objects.filter(lecture__year__exact=next_year, lecture__semester=next_semester).delete()
         for row in class_times:
             print(row)
-            myrow = []
-            for elem in row:
-                if isinstance(elem, bytes):
-                    try:
-                        elem = elem.decode(encoding)
-                    except UnicodeDecodeError:
-                        elem = "???"
-                        print("ERROR: parsing error on lecture. cannot read in cp949.", file=sys.stderr)
-                myrow.append(elem)
+            myrow = row[:]
             lecture_key = {
                 "deleted": False,
                 "code": myrow[2],
@@ -370,16 +345,7 @@ class Command(BaseCommand):
         Syllabus.objects.filter(lecture__year__exact=next_year, lecture__semester=next_semester).delete()
 
         for row in syllabuses:
-            myrow = []
-            for elem in row:
-                if isinstance(elem, bytes):
-                    try:
-                        elem = elem.decode(encoding)
-                    except UnicodeDecodeError:
-                        eleme = u'%s (???)' % row[2]
-                        print>>sys.stderr, 'ERROR: parsing error on lecture %s' % row[2]
-                        print>>sys.stderr, '       cannot read "%s" in cp949.' % elem
-                myrow.append(elem)
+            myrow = row[:]
             lecture_key = {
                 'code': myrow[2],
                 'year': int(myrow[0]),

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -214,14 +214,16 @@ class Command(BaseCommand):
                 lecture.save()
                 lecture_count += 1
                 # professor save
-                match_scholar = filter(
-                    lambda a: lecture.year == a[0]
-                    and lecture.semester == a[1]
-                    and lecture.code == a[2]
-                    and lecture.class_no.strip() == a[3].strip()
-                    and lecture.department_id == a[4],
+                match_scholar = list(filter(
+                    lambda p: (
+                        lecture.year == p[0]
+                        and lecture.semester == p[1]
+                        and lecture.code == p[2]
+                        and lecture.class_no.strip() == p[3].strip()
+                        and lecture.department_id == p[4]
+                    ),
                     professors,
-                )
+                ))
                 if len(match_scholar) != 0:
                     professors_not_updated = set()
                     for prof in lecture.professors.all():

--- a/apps/subject/management/commands/import-user-major.py
+++ b/apps/subject/management/commands/import-user-major.py
@@ -29,6 +29,7 @@ class Command(BaseCommand):
         port = options.get("port", None)
         user = options.get("user", None)
         password = options.get("password", None)
+        encoding = options.get("encoding")
         all_ = options.get("all", None)
         student_id = options.get("studentid", None)
         try:
@@ -71,11 +72,11 @@ class Command(BaseCommand):
 
         for a in user_major_minor:
             profile_matches = UserProfile.objects.filter(student_id=a[0])
-            departments = Department.objects.filter(name=a[2].decode("cp949"))
+            departments = Department.objects.filter(name=a[2].decode(encoding))
 
             for user in profile_matches:
                 for d in departments:
-                    if a[1].decode("cp949") == "부전공신청":
+                    if a[1].decode(encoding) == "부전공신청":
                         user.minors.add(d)
                     elif a[1].decode("cp949") == "복수전공신청":
                         user.majors.add(d)

--- a/apps/subject/management/commands/import-user-major.py
+++ b/apps/subject/management/commands/import-user-major.py
@@ -76,9 +76,10 @@ class Command(BaseCommand):
 
             for user in profile_matches:
                 for d in departments:
-                    if a[1].decode(encoding) == "부전공신청":
+                    application_type = a[1].decode(encoding) if isinstance(a[1], bytes) else a[1]
+                    if application_type == "부전공신청":
                         user.minors.add(d)
-                    elif a[1].decode("cp949") == "복수전공신청":
+                    elif application_type == "복수전공신청":
                         user.majors.add(d)
                     else:
                         print("Major/minor type not matching : " % (a.decode("cp959")))

--- a/apps/subject/management/commands/import-user-major.py
+++ b/apps/subject/management/commands/import-user-major.py
@@ -72,11 +72,11 @@ class Command(BaseCommand):
 
         for a in user_major_minor:
             profile_matches = UserProfile.objects.filter(student_id=a[0])
-            departments = Department.objects.filter(name=a[2].decode(encoding))
+            departments = Department.objects.filter(name=a[2])
 
             for user in profile_matches:
                 for d in departments:
-                    application_type = a[1].decode(encoding) if isinstance(a[1], bytes) else a[1]
+                    application_type = a[1]
                     if application_type == "부전공신청":
                         user.minors.add(d)
                     elif application_type == "복수전공신청":

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ urllib3==1.26.6
 jsonpickle==2.0.0
 flake8==3.9.2
 black==21.6b0
+pyodbc==4.0.32
 pytest==6.2.4
 pytest-django==4.4.0
 pytest-cov==2.12.1

--- a/scholardb_access.py
+++ b/scholardb_access.py
@@ -24,7 +24,7 @@ def execute(host, port, user, password, query):
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 python db.py > /dev/null")
     os.system("scp -i ~/key.pem -P 8022 wheel@143.248.234.126:/tmp/otl_db_dump_result /tmp > /dev/null")
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 rm /tmp/otl_db_dump_result > /dev/null")
-    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"))
+    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="latin1")
     os.remove("/tmp/otl_db_dump_result")
 
     return result

--- a/scholardb_access.py
+++ b/scholardb_access.py
@@ -24,7 +24,12 @@ def execute(host, port, user, password, query):
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 python db.py > /dev/null")
     os.system("scp -i ~/key.pem -P 8022 wheel@143.248.234.126:/tmp/otl_db_dump_result /tmp > /dev/null")
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 rm /tmp/otl_db_dump_result > /dev/null")
-    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="cp949")
+    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="bytes")
     os.remove("/tmp/otl_db_dump_result")
+
+    for row in result:
+        for j, elem in enumerate(row):
+            if isinstance(elem, bytes):
+                row[j] = elem.decode("cp949")
 
     return result

--- a/scholardb_access.py
+++ b/scholardb_access.py
@@ -24,7 +24,7 @@ def execute(host, port, user, password, query):
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 python db.py > /dev/null")
     os.system("scp -i ~/key.pem -P 8022 wheel@143.248.234.126:/tmp/otl_db_dump_result /tmp > /dev/null")
     os.system("ssh -i ~/key.pem -p 8022 wheel@143.248.234.126 rm /tmp/otl_db_dump_result > /dev/null")
-    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="latin1")
+    result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="cp949")
     os.remove("/tmp/otl_db_dump_result")
 
     return result

--- a/scholardb_access.py
+++ b/scholardb_access.py
@@ -30,6 +30,10 @@ def execute(host, port, user, password, query):
     for row in result:
         for j, elem in enumerate(row):
             if isinstance(elem, bytes):
-                row[j] = elem.decode("cp949")
+                try:
+                    row[j] = elem.decode("cp949")
+                except UnicodeDecodeError as e:
+                    print(f"Cannot decode {elem}")
+                    print(e)
 
     return result


### PR DESCRIPTION
Python 3 업데이트 당시 학사디비 import 관련 스크립트는 제대로 처리가 안 된 것 같은데 오류를 수정하였습니다.

- Python 3으로 업데이트하며 누락된 패키지 추가
- Python 3으로 업데이트하며 str 및 pickle의 encoding 오류 수정
- Python 3으로 업데이트하며 기본 함수 filter()의 return type 변경으로 인한 오류 수정

이미 개발환경 설정하신 분은 pip install 과정에서 unixodbc를 설치해야 할 수 있습니다. (README 참고)