### PR TITLE
Added ordering and pagination to more list get requests

### DIFF
--- a/apps/review/models.py
+++ b/apps/review/models.py
@@ -16,10 +16,13 @@ class Review(models.Model):
 
     writer = models.ForeignKey(UserProfile, related_name="reviews", db_index=True, on_delete=models.SET_NULL, null=True)
     writer_label = models.CharField(max_length=200, default="무학과 넙죽이")
-    updated_datetime = models.DateTimeField(auto_now=True, db_index=True)
-    written_datetime = models.DateTimeField(auto_now_add=True, db_index=True, null=True)
     like = models.IntegerField(default=0)
     is_deleted = models.IntegerField(default=0)
+
+    # WARNING: Some old reviews have written_datetime = null. You may need extra filtering/ordering with id.
+    written_datetime = models.DateTimeField(auto_now_add=True, db_index=True, null=True)
+    # TODO: Modify updated_datetime not to capture changes on field 'like' and all other changes not triggered by writer
+    updated_datetime = models.DateTimeField(auto_now=True, db_index=True)
 
     class Meta:
         unique_together = (

--- a/apps/subject/views.py
+++ b/apps/subject/views.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from utils.decorators import login_required_ajax
-from utils.util import apply_offset_and_limit
+from utils.util import apply_offset_and_limit, apply_order
 
 from .models import Semester, Course, Lecture, Professor, CourseUser
 from . import services
@@ -12,18 +12,22 @@ from apps.review.models import Review
 
 
 class SemesterListView(View):
-    def get(self, request):
-        semesters = Semester.objects.all().order_by("year", "semester")
+    DEFAULT_ORDER = ['year', 'semester']
 
+    def get(self, request):
+        semesters = Semester.objects.all()
+
+        semesters = apply_order(semesters, request.GET, SemesterListView.DEFAULT_ORDER)
         result = [semester.toJson() for semester in semesters]
         return JsonResponse(result, safe=False)
 
 
 class CourseListView(View):
     MAX_LIMIT = 150
+    DEFAULT_ORDER = ['old_code']
 
     def get(self, request):
-        courses = Course.objects.all().order_by("old_code")
+        courses = Course.objects.all()
         courses = services.filter_lectures_from_querystring(courses, request.GET)
 
         term = request.GET.get("term", None)
@@ -33,6 +37,7 @@ class CourseListView(View):
         # .select_related('department') \
         # .prefetch_related('related_courses_prior', 'related_courses_posterior', 'professors', 'read_users_courseuser')
 
+        courses = apply_order(courses, request.GET, CourseListView.DEFAULT_ORDER)
         courses = apply_offset_and_limit(courses, request.GET, CourseListView.MAX_LIMIT)
         result = [c.toJson(user=request.user) for c in courses]
         return JsonResponse(result, safe=False)
@@ -63,20 +68,27 @@ class CourseListAutocompleteView(View):
 
 
 class CourseInstanceReviewsView(View):
+    MAX_LIMIT = 100
+    DEFAULT_ORDER = ['-lecture__year', '-lecture__semester', '-written_datetime']
+
     def get(self, request, course_id):
         course = get_object_or_404(Course, id=course_id)
-        reviews = course.reviews.all().order_by("-lecture__year", "-written_datetime")
-        reviews = reviews[:100]
+        reviews = course.reviews.all()
 
+        reviews = apply_order(reviews, request.GET, CourseInstanceReviewsView.DEFAULT_ORDER)
+        reviews = apply_offset_and_limit(reviews, request.GET, CourseInstanceReviewsView.MAX_LIMIT)
         result = [review.toJson(user=request.user) for review in reviews]
         return JsonResponse(result, safe=False)
 
 
 class CourseInstanceLecturesView(View):
+    DEFAULT_ORDER = ['year', 'semester', 'class_no']
+
     def get(self, request, course_id):
         course = get_object_or_404(Course, id=course_id)
-        lectures = course.lectures.filter(deleted=False).order_by("year", "semester", "class_no")
+        lectures = course.lectures.filter(deleted=False)
 
+        lectures = apply_order(lectures, request.GET, CourseInstanceLecturesView.DEFAULT_ORDER)
         result = [lecture.toJson() for lecture in lectures]
         return JsonResponse(result, safe=False)
 
@@ -97,6 +109,7 @@ class CourseInstanceReadView(View):
 
 class LectureListView(View):
     MAX_LIMIT = 300
+    DEFAULT_ORDER = ['year', 'semester', 'old_code', 'class_no']
 
     def get(self, request):
         lectures = Lecture.objects.filter(deleted=False).exclude(Lecture.getQueryResearch())
@@ -112,10 +125,11 @@ class LectureListView(View):
 
         lectures = services.filter_lectures_from_querystring(lectures, request.GET)
 
-        lectures = lectures.distinct().order_by("old_code", "class_no")
+        # lectures = lectures
         # .select_related('course', 'department') \
         # .prefetch_related('classtimes', 'examtimes', 'professors') \
 
+        lectures = apply_order(lectures, request.GET, LectureListView.DEFAULT_ORDER)
         lectures = apply_offset_and_limit(lectures, request.GET, LectureListView.MAX_LIMIT)
         result = [lecture.toJson(nested=False) for lecture in lectures]
         return JsonResponse(result, safe=False)
@@ -148,33 +162,46 @@ class LectureListAutocompleteView(View):
 
 
 class LectureInstanceReviewsView(View):
+    MAX_LIMIT = 100
+    DEFAULT_ORDER = ['-written_datetime', '-id']
+
     def get(self, request, lecture_id):
         lecture = get_object_or_404(Lecture, id=lecture_id)
-        reviews = lecture.reviews.all().order_by("-id")
+        reviews = lecture.reviews.all()
 
+        reviews = apply_order(reviews, request.GET, LectureInstanceReviewsView.DEFAULT_ORDER)
+        reviews = apply_offset_and_limit(reviews, request.GET, LectureInstanceReviewsView.MAX_LIMIT)
         result = [review.toJson() for review in reviews]
         return JsonResponse(result, safe=False)
 
 
 class LectureInstanceRelatedReviewsView(View):
+    MAX_LIMIT = 100
+    DEFAULT_ORDER = ['-written_datetime', '-id']
+
     def get(self, request, lecture_id):
         lecture = get_object_or_404(Lecture, id=lecture_id)
         reviews = Review.objects.filter(
             lecture__course=lecture.course,
             lecture__professors__in=lecture.professors.all(),
-        ).order_by("-id")
+        )
 
+        reviews = apply_order(reviews, request.GET, LectureInstanceRelatedReviewsView.DEFAULT_ORDER)
+        reviews = apply_offset_and_limit(reviews, request.GET, LectureInstanceRelatedReviewsView.MAX_LIMIT)
         result = [review.toJson() for review in reviews]
         return JsonResponse(result, safe=False)
 
 
 @method_decorator(login_required_ajax, name="dispatch")
 class UserInstanceTakenCoursesView(View):
+    DEFAULT_ORDER = ['old_code']
+
     def get(self, request, user_id):
         userprofile = request.user.userprofile
         if userprofile.id != int(user_id):
             return HttpResponse(status=401)
-        courses = Course.objects.filter(lectures__in=userprofile.taken_lectures.all()).order_by("old_code").distinct()
+        courses = Course.objects.filter(lectures__in=userprofile.taken_lectures.all())
 
+        courses = apply_order(courses, request.GET, UserInstanceTakenCoursesView.DEFAULT_ORDER)
         result = [course.toJson(user=request.user) for course in courses]
         return JsonResponse(result, safe=False)

--- a/apps/subject/views.py
+++ b/apps/subject/views.py
@@ -69,7 +69,7 @@ class CourseListAutocompleteView(View):
 
 class CourseInstanceReviewsView(View):
     MAX_LIMIT = 100
-    DEFAULT_ORDER = ['-lecture__year', '-lecture__semester', '-written_datetime']
+    DEFAULT_ORDER = ['-lecture__year', '-lecture__semester', '-written_datetime', '-id']
 
     def get(self, request, course_id):
         course = get_object_or_404(Course, id=course_id)

--- a/apps/subject/views.py
+++ b/apps/subject/views.py
@@ -4,7 +4,7 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from utils.decorators import login_required_ajax
-from utils.util import getint, get_paginated_queryset
+from utils.util import apply_offset_and_limit
 
 from .models import Semester, Course, Lecture, Professor, CourseUser
 from . import services
@@ -33,9 +33,7 @@ class CourseListView(View):
         # .select_related('department') \
         # .prefetch_related('related_courses_prior', 'related_courses_posterior', 'professors', 'read_users_courseuser')
 
-        offset = getint(request.GET, "offset", None)
-        limit = getint(request.GET, "limit", None)
-        courses = get_paginated_queryset(courses, offset, limit, self.MAX_LIMIT)
+        courses = apply_offset_and_limit(courses, request.GET, CourseListView.MAX_LIMIT)
         result = [c.toJson(user=request.user) for c in courses]
         return JsonResponse(result, safe=False)
 
@@ -118,9 +116,7 @@ class LectureListView(View):
         # .select_related('course', 'department') \
         # .prefetch_related('classtimes', 'examtimes', 'professors') \
 
-        offset = getint(request.GET, "offset", None)
-        limit = getint(request.GET, "limit", None)
-        lectures = get_paginated_queryset(lectures, offset, limit, self.MAX_LIMIT)
+        lectures = apply_offset_and_limit(lectures, request.GET, LectureListView.MAX_LIMIT)
         result = [lecture.toJson(nested=False) for lecture in lectures]
         return JsonResponse(result, safe=False)
 

--- a/apps/support/views.py
+++ b/apps/support/views.py
@@ -7,12 +7,14 @@ from django.utils.decorators import method_decorator
 from django.views import View
 
 from utils.decorators import login_required_ajax
-from utils.util import getint
+from utils.util import apply_order, getint
 
 from .models import Notice, Rate
 
 
 class NoticeListView(View):
+    DEFAULT_ORDER = ['start_time', 'id']
+
     def get(self, request):
         notices = Notice.objects.all()
 
@@ -20,6 +22,7 @@ class NoticeListView(View):
         if time:
             notices = notices.filter(start_time__lte=time, end_time__gte=time)
 
+        notices = apply_order(notices, request.GET, NoticeListView.DEFAULT_ORDER)
         result = [n.toJson() for n in notices]
         return JsonResponse(result, safe=False)
 

--- a/react/src/App.js
+++ b/react/src/App.js
@@ -55,6 +55,9 @@ class App extends Component {
     axios.get(
       '/api/semesters',
       {
+        params: {
+          order: ['year', 'semester'],
+        },
         metadata: {
           gaCategory: 'Semester',
           gaVariable: 'GET / List',

--- a/react/src/components/sections/dictionary/CourseDetailSection.js
+++ b/react/src/components/sections/dictionary/CourseDetailSection.js
@@ -58,6 +58,9 @@ class CourseDetailSection extends Component {
     axios.get(
       `/api/courses/${courseFocus.course.id}/lectures`,
       {
+        params: {
+          order: ['year', 'semester', 'class_no'],
+        },
         metadata: {
           gaCategory: 'Course',
           gaVariable: 'GET Lectures / Instance',
@@ -82,6 +85,9 @@ class CourseDetailSection extends Component {
     axios.get(
       `/api/courses/${courseFocus.course.id}/reviews`,
       {
+        params: {
+          order: ['-lecture__year', '-lecture__semester', '-written_datetime', '-id'],
+        },
         metadata: {
           gaCategory: 'Course',
           gaVariable: 'GET Reviews / Instance',

--- a/react/src/components/sections/dictionary/CourseDetailSection.js
+++ b/react/src/components/sections/dictionary/CourseDetailSection.js
@@ -80,6 +80,8 @@ class CourseDetailSection extends Component {
 
 
   _fetchReviews = () => {
+    const LIMIT = 100;
+
     const { courseFocus, setReviewsDispatch } = this.props;
 
     axios.get(
@@ -87,6 +89,7 @@ class CourseDetailSection extends Component {
       {
         params: {
           order: ['-lecture__year', '-lecture__semester', '-written_datetime', '-id'],
+          limit: LIMIT,
         },
         metadata: {
           gaCategory: 'Course',
@@ -100,6 +103,9 @@ class CourseDetailSection extends Component {
           return;
         }
         this._markRead(courseFocus.course);
+        if (response.data.length === LIMIT) {
+          // TODO: handle limit overflow
+        }
         setReviewsDispatch(response.data);
       })
       .catch((error) => {

--- a/react/src/components/sections/dictionary/CourseListTabs.js
+++ b/react/src/components/sections/dictionary/CourseListTabs.js
@@ -70,6 +70,7 @@ class CourseListTabs extends Component {
         params: {
           group: 'Basic',
           term: ['3'],
+          order: ['old_code'],
         },
         metadata: {
           gaCategory: 'Course',
@@ -93,6 +94,7 @@ class CourseListTabs extends Component {
         params: {
           group: [majorCode],
           term: ['3'],
+          order: ['old_code'],
         },
         metadata: {
           gaCategory: 'Course',
@@ -120,6 +122,7 @@ class CourseListTabs extends Component {
         params: {
           group: 'Humanity',
           term: ['3'],
+          order: ['old_code'],
         },
         metadata: {
           gaCategory: 'Course',
@@ -147,6 +150,7 @@ class CourseListTabs extends Component {
       `/api/users/${user.id}/taken-courses`,
       {
         params: {
+          order: ['old_code'],
         },
         metadata: {
           gaCategory: 'User',

--- a/react/src/components/sections/dictionary/CourseSearchSubSection.js
+++ b/react/src/components/sections/dictionary/CourseSearchSubSection.js
@@ -42,6 +42,8 @@ class CourseSearchSubSection extends Component {
   }
 
   searchStart = () => {
+    const LIMIT = 150;
+
     const { t } = this.props;
     const {
       selectedTypes, selectedDepartments, selectedLevels, selectedTerms,
@@ -83,6 +85,7 @@ class CourseSearchSubSection extends Component {
         params: {
           ...option,
           order: ['old_code'],
+          limit: LIMIT,
         },
         metadata: {
           gaCategory: 'Course',
@@ -91,6 +94,10 @@ class CourseSearchSubSection extends Component {
       },
     )
       .then((response) => {
+        if (response.data.length === LIMIT) {
+          // eslint-disable-next-line no-alert
+          alert(t('ui.message.tooManySearchResults', { count: LIMIT }));
+        }
         setListCoursesDispatch(SEARCH, response.data);
       })
       .catch((error) => {

--- a/react/src/components/sections/dictionary/CourseSearchSubSection.js
+++ b/react/src/components/sections/dictionary/CourseSearchSubSection.js
@@ -82,6 +82,7 @@ class CourseSearchSubSection extends Component {
       {
         params: {
           ...option,
+          order: ['old_code'],
         },
         metadata: {
           gaCategory: 'Course',

--- a/react/src/components/sections/main/LatestReviewSection.js
+++ b/react/src/components/sections/main/LatestReviewSection.js
@@ -24,7 +24,7 @@ class LatestReviewSection extends Component {
       '/api/reviews',
       {
         params: {
-          order: ['-written_datetime'],
+          order: ['-written_datetime', '-id'],
           offset: 0,
           limit: 3,
         },

--- a/react/src/components/sections/timetable/LectureDetailSection.js
+++ b/react/src/components/sections/timetable/LectureDetailSection.js
@@ -90,13 +90,18 @@ class LectureDetailSection extends Component {
   }
 
   _loadReviews = () => {
+    const LIMIT = 100;
+
     const { lectureFocus, setReviewsDispatch } = this.props;
 
     if (lectureFocus.reviews === null) {
       axios.get(
         `/api/lectures/${lectureFocus.lecture.id}/related-reviews`,
         {
-          order: ['-written_datetime', '-id'],
+          params: {
+            order: ['-written_datetime', '-id'],
+            limit: LIMIT,
+          },
           metadata: {
             gaCategory: 'Lecture',
             gaVariable: 'GET Related Reviews / Instance',
@@ -107,6 +112,9 @@ class LectureDetailSection extends Component {
           const newProps = this.props;
           if (newProps.lectureFocus.lecture.id !== lectureFocus.lecture.id) {
             return;
+          }
+          if (response.data === LIMIT) {
+            // TODO: handle limit overflow
           }
           setReviewsDispatch(response.data);
         })

--- a/react/src/components/sections/timetable/LectureDetailSection.js
+++ b/react/src/components/sections/timetable/LectureDetailSection.js
@@ -96,6 +96,7 @@ class LectureDetailSection extends Component {
       axios.get(
         `/api/lectures/${lectureFocus.lecture.id}/related-reviews`,
         {
+          order: ['-written_datetime', '-id'],
           metadata: {
             gaCategory: 'Lecture',
             gaVariable: 'GET Related Reviews / Instance',

--- a/react/src/components/sections/timetable/LectureListTabs.js
+++ b/react/src/components/sections/timetable/LectureListTabs.js
@@ -95,6 +95,7 @@ class LectureListTabs extends Component {
           year: year,
           semester: semester,
           group: 'Basic',
+          order: ['old_code', 'class_no'],
         },
         metadata: {
           gaCategory: 'Lecture',
@@ -126,6 +127,7 @@ class LectureListTabs extends Component {
           year: year,
           semester: semester,
           group: [majorCode],
+          order: ['old_code', 'class_no'],
         },
         metadata: {
           gaCategory: 'Lecture',
@@ -159,6 +161,7 @@ class LectureListTabs extends Component {
           year: year,
           semester: semester,
           group: 'Humanity',
+          order: ['old_code', 'class_no'],
         },
         metadata: {
           gaCategory: 'Lecture',

--- a/react/src/components/sections/timetable/LectureSearchSubSection.js
+++ b/react/src/components/sections/timetable/LectureSearchSubSection.js
@@ -91,6 +91,7 @@ class LectureSearchSubSection extends Component {
           year: year,
           semester: semester,
           ...option,
+          order: ['old_code', 'class_no'],
         },
         metadata: {
           gaCategory: 'Timetable',

--- a/react/src/components/sections/timetable/LectureSearchSubSection.js
+++ b/react/src/components/sections/timetable/LectureSearchSubSection.js
@@ -41,6 +41,8 @@ class LectureSearchSubSection extends Component {
   }
 
   searchStart = () => {
+    const LIMIT = 300;
+
     const { t } = this.props;
     const {
       selectedTypes, selectedDepartments, selectedLevels,
@@ -92,6 +94,7 @@ class LectureSearchSubSection extends Component {
           semester: semester,
           ...option,
           order: ['old_code', 'class_no'],
+          limit: LIMIT,
         },
         metadata: {
           gaCategory: 'Timetable',
@@ -104,8 +107,11 @@ class LectureSearchSubSection extends Component {
         if (newProps.year !== year || newProps.semester !== semester) {
           return;
         }
-        const lectures = response.data;
-        setListLecturesDispatch(SEARCH, lectures);
+        if (response.data.length === LIMIT) {
+          // eslint-disable-next-line no-alert
+          alert(t('ui.message.tooManySearchResults', { count: LIMIT }));
+        }
+        setListLecturesDispatch(SEARCH, response.data);
       })
       .catch((error) => {
       });

--- a/react/src/components/sections/timetable/TimetableTabs.js
+++ b/react/src/components/sections/timetable/TimetableTabs.js
@@ -75,6 +75,7 @@ class TimetableTabs extends Component {
         params: {
           year: year,
           semester: semester,
+          order: ['id'],
         },
         metadata: {
           gaCategory: 'Timetable',

--- a/react/src/components/sections/write-reviews/LatestReviewsSubSection.js
+++ b/react/src/components/sections/write-reviews/LatestReviewsSubSection.js
@@ -60,7 +60,7 @@ class LatestReviewsSubSection extends Component {
       '/api/reviews',
       {
         params: {
-          order: ['-written_datetime'],
+          order: ['-written_datetime', '-id'],
           offset: offset,
           limit: PAGE_SIZE,
         },

--- a/react/src/components/sections/write-reviews/LectureReviewsSubSection.js
+++ b/react/src/components/sections/write-reviews/LectureReviewsSubSection.js
@@ -42,6 +42,9 @@ class LectureReviewsSubSection extends Component {
     axios.get(
       `/api/lectures/${reviewsFocus.lecture.id}/related-reviews`,
       {
+        params: {
+          order: ['-written_datetime', '-id'],
+        },
         metadata: {
           gaCategory: 'Course',
           gaVariable: 'GET Reviews / Instance',

--- a/react/src/components/sections/write-reviews/LikedReviewsSubSection.js
+++ b/react/src/components/sections/write-reviews/LikedReviewsSubSection.js
@@ -48,6 +48,9 @@ class LikedReviewsSubSection extends Component {
     axios.get(
       `/api/users/${user.id}/liked-reviews`,
       {
+        params: {
+          order: ['-written_datetime', '-id'],
+        },
         metadata: {
           gaCategory: 'User',
           gaVariable: 'GET Liked Reviews / Instance',

--- a/react/src/components/sections/write-reviews/RankedReviewsSubSection.js
+++ b/react/src/components/sections/write-reviews/RankedReviewsSubSection.js
@@ -106,12 +106,10 @@ class RankedReviewsSubSection extends Component {
     const { selectedSemester } = this.state;
     const { setSemesterReviewCountDispatch } = this.props;
 
-    const params = (selectedSemester === ALL)
+    const options = (selectedSemester === ALL)
       ? {
-        response_type: 'count',
       }
       : {
-        response_type: 'count',
         lecture_year: selectedSemester.year,
         lecture_semester: selectedSemester.semester,
       };
@@ -119,7 +117,10 @@ class RankedReviewsSubSection extends Component {
     axios.get(
       '/api/reviews',
       {
-        params: params,
+        params: {
+          ...options,
+          response_type: 'count',
+        },
         metadata: {
           gaCategory: 'Review',
           gaVariable: 'GET / List Count',
@@ -145,16 +146,10 @@ class RankedReviewsSubSection extends Component {
     }
 
     const offset = (this._getReviewsOfSemester(selectedSemester) || []).length;
-    const params = (selectedSemester === ALL)
+    const options = (selectedSemester === ALL)
       ? {
-        order: ['-like'],
-        offset: offset,
-        limit: PAGE_SIZE,
       }
       : {
-        order: ['-like'],
-        offset: offset,
-        limit: PAGE_SIZE,
         lecture_year: selectedSemester.year,
         lecture_semester: selectedSemester.semester,
       };
@@ -165,7 +160,12 @@ class RankedReviewsSubSection extends Component {
     axios.get(
       '/api/reviews',
       {
-        params: params,
+        params: {
+          ...options,
+          order: ['-like'],
+          offset: offset,
+          limit: PAGE_SIZE,
+        },
         metadata: {
           gaCategory: 'Review',
           gaVariable: 'GET Latest / List',

--- a/react/src/pages/DictionaryPage.js
+++ b/react/src/pages/DictionaryPage.js
@@ -27,6 +27,8 @@ import {
 
 class DictionaryPage extends Component {
   componentDidMount() {
+    const LIMIT = 300;
+
     const { t } = this.props;
     // eslint-disable-next-line react/destructuring-assignment
     const { startCourseId, startTab, startSearchKeyword } = this.props.location.state || {};
@@ -66,6 +68,7 @@ class DictionaryPage extends Component {
           params: {
             keyword: startSearchKeyword,
             order: ['old_code'],
+            limit: LIMIT,
           },
           metadata: {
             gaCategory: 'Course',
@@ -74,6 +77,10 @@ class DictionaryPage extends Component {
         },
       )
         .then((response) => {
+          if (response.data.length === LIMIT) {
+            // eslint-disable-next-line no-alert
+            alert(t('ui.message.tooManySearchResults', { count: LIMIT }));
+          }
           setListCoursesDispatch(SEARCH, response.data);
         })
         .catch((error) => {

--- a/react/src/pages/DictionaryPage.js
+++ b/react/src/pages/DictionaryPage.js
@@ -65,6 +65,7 @@ class DictionaryPage extends Component {
         {
           params: {
             keyword: startSearchKeyword,
+            order: ['old_code'],
           },
           metadata: {
             gaCategory: 'Course',

--- a/react/src/pages/MainPage.js
+++ b/react/src/pages/MainPage.js
@@ -166,6 +166,7 @@ class MainPage extends Component {
       {
         params: {
           time: now.toJSON(),
+          order: ['start_time', 'id'],
         },
         metadata: {
           gaCategory: 'Notice',

--- a/react/src/translations/translation.en.json
+++ b/react/src/translations/translation.en.json
@@ -230,6 +230,7 @@
       "scoreNotSelected": "Please select all scores.",
       "reportUnderDevelopment": "This featuer is under development. Please report improper reviews to otlplus@sparcs.org.",
       "alreadyRated": "You already rated OTL.",
+      "tooManySearchResults": "There are too many search results. Only {{count}} will be displayed.",
       "myInfoCaptionHead": "You can change this information at ",
       "myInfoCaptionTail": ".",
       "academicInfoCaptionHead": "This information is fetched from KAIST Portal. In case the information is not correct, please contact ",

--- a/react/src/translations/translation.ko.json
+++ b/react/src/translations/translation.ko.json
@@ -230,6 +230,7 @@
       "scoreNotSelected": "평가를 선택해 주세요.",
       "reportUnderDevelopment": "이 기능은 현재 개발중입니다. 부적절한 후기는 otlplus@sparcs.org로 신고해 주세요.",
       "alreadyRated": "이미 평가하였습니다.",
+      "tooManySearchResults": "검색 결과가 너무 많습니다. {{count}}개만 표시됩니다.",
       "myInfoCaptionHead": "이 정보는 ",
       "myInfoCaptionTail": "에서 변경하실 수 있습니다.",
       "academicInfoCaptionHead": "이 정보는 KAIST Portal과 연동됩니다. 정보가 일치하지 않을 경우 ",

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,4 +1,5 @@
 from functools import reduce
+import re
 
 from django.db.models import QuerySet
 from django.http import QueryDict
@@ -37,7 +38,16 @@ def apply_offset_and_limit(queryset: QuerySet, params: QueryDict, max_limit: int
 
 
 def apply_order(queryset: QuerySet, params: QueryDict, default_order: list = []) -> QuerySet:
+    PROHIBITED_FIELD_PATTERN = [
+        r"\?",
+        r"user", r"profile", r"owner", r"writer",
+        r"__.*__"
+    ]
+
     order = params.getlist("order", default_order)
+    if any(re.match(p, o) for p in PROHIBITED_FIELD_PATTERN for o in order):
+        raise ValueError
+
     return queryset.order_by(*order).distinct()
 
 

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,5 +1,8 @@
 from functools import reduce
 
+from django.db.models import QuerySet
+from django.http import QueryDict
+
 
 def rgetattr(object_, names, default):
     return reduce(lambda o, n: getattr(o, n, default), names, object_)
@@ -13,7 +16,8 @@ def getint(querydict, key, default=None):
         return int(value)
 
 
-def get_paginated_queryset(queryset, offset, limit, max_limit=150):
+def apply_offset_and_limit(queryset: QuerySet, params: QueryDict, max_limit: int = 150) -> QuerySet:
+    offset = getint(params, "offset", None)
     if offset is None:
         real_offest = 0
     elif offset >= 0:
@@ -21,6 +25,7 @@ def get_paginated_queryset(queryset, offset, limit, max_limit=150):
     else:
         raise ValueError
 
+    limit = getint(params, "limit", None)
     if limit is None:
         real_limit = max_limit
     elif 0 <= limit <= max_limit:
@@ -29,6 +34,11 @@ def get_paginated_queryset(queryset, offset, limit, max_limit=150):
         raise ValueError
 
     return queryset[real_offest : real_offest + real_limit]
+
+
+def apply_order(queryset: QuerySet, params: QueryDict, default_order: list = []) -> QuerySet:
+    order = params.getlist("order", default_order)
+    return queryset.order_by(*order).distinct()
 
 
 def patch_object(object_, update_fields):


### PR DESCRIPTION
변화의 목적은 다음과 같습니다.
- API 호출 parameter의 통일성
- 클라이언트가 response의 order 및 limit을 명시적으로 알거나 지정할 수 있게 함
- 클라이언트가 서버상의 기본값 변화에 영향받지 않게 함

서버 변경점
- 일부 list get 에만 적용되었던 ordering(order)과 pagination(offset, limt)을 모든 list get api에 적용하였습니다.
- order, offset, limit은 항상 optional이며, 입력하지 않을 경우 기본값은 아래의 경우를 제외하고 변경 전과 동일합니다.
  - reviews의 default_order가 ['id']에서 ['-written_datetime', '-id']로 변경됩니다. 단, 기존에도 웹 클라이언트에서는 reviews는 항상 order를 명시하여 사용하였으므로 차이가 없습니다.
  - users/{id}/liked-reviews의 default_order가 ['id'] 에서 ['-written_datetime', '-id']로 변경됩니다. **이로 인해 liked reviews가 기존의 역순으로 제공되는 변화가 있습니다**.
  - users/{id}/liked-reviews의 max_limit이 500에서 300으로 변경됩니다. 실질적인 차이가 없을 것으로 보이나 **극히 일부 좋아요를 매우 많이 누른 사용자에게 영향이 있을 수 있습니다**.
  - courses/{id}/reviews의 default_order가 ['-lecture__year', '-written_datetime']에서 ['-lecture__year', '-lecture__semester', '-written_datetime', '-id']로 변경되었습니다. 순서에 큰 차이는 없으나 **일부 마이너한 변동이 있습니다**.
  - lectures의 default_order가 ['old_code', 'class_no']에서 ['year', 'semester', 'old_code', 'class_no']로 변경됩니다. 단, 기존에도 웹 클라이언트에서는 lectures는 항상 year 및 semester로 필터한 request만 사용하였으므로 차이가 없습니다.
  - lectures/{id}/reviews 및 lectures/{id}/related-reviews의 max_limit이 INFINITY에서 100으로 변경됩니다. **일부 후기가 매우 많은 과목에 영향이 있을 수 있습니다**.
  - notices의 default_order가 ['id']에서 ['start_time', 'id']로 변경됩니다. 단, 기존에도 notice의 id순서와 생성 순서, start_time의 순서가 일치했으므로 기존 데이터 상에서는 차이 거의 없습니다.
  - users/{id}/timetables의 default_order가 ['id']에서 ['year', 'semester', 'id']로 변경됩니다. 단, 기존에도 웹과 앱 클라이언트에서는 timetables는 항상 year 및 semester로 필터한 request만 사용하였으므로 차이가 없습니다.
  - users/{id}/timetables의 max_limit이 INFINITY에서 50으로 변경됩니다. 실질적인 차이가 없습니다.
  
웹 클라이언트 변경점
- 대부분의 list get request에 order를 명시적으로 추가하였습니다. 단, 새로 추가된 부분에서는 모두 서버에서의 기본값을 그대로 사용합니다.
- 몇몇 list get request에 limit을 명시적으로 추가하였습니다. 단 MAX_LIMIT을 넘을 가능성이 없는 request는 제외하였습니다.
- TODO: limit을 넘을 경우 스크롤 시 추가적으로 불러오거나 limit을 넘었다는 점을 사용자에게 표시하는 등 추가적인 처리가 필요합니다.

앱 클라이언트 변경 예정
- sparcs-kaist/otl-app#39 