### PR TITLE
Updated scholardb and taken-lecture import scripts to expand semesters

### DIFF
--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -121,8 +121,10 @@ class Command(BaseCommand):
         password = db_specification["password"]
         encoding = db_specification["encoding"]
 
-        rx_dept_code = re.compile(r"([a-zA-Z]+)(\d+)")
         lecture_count = 0
+
+        def _extract_department_code(lecture_old_code):
+            return re.compile(r"([a-zA-Z]+)(\d+)").match(lecture_old_code).group(1)
 
         if not exclude_lecture:
             query = "SELECT * FROM view_OTL_charge WHERE lecture_year = %d AND lecture_term = %d" % (
@@ -160,7 +162,7 @@ class Command(BaseCommand):
                 lecture_class_no = myrow[3].strip()
                 department_no = lecture_no[0:2]
                 department_id = int(myrow[4])
-                department_code = rx_dept_code.match(lecture_code).group(1)
+                department_code = _extract_department_code(lecture_code)
 
                 # Update department info.
                 if prev_department != department_id:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -9,6 +9,8 @@ import re
 
 from scholardb_access import execute
 
+from utils.command_utils import get_target_semesters
+
 
 class Command(BaseCommand):
     def add_arguments(self, parser):
@@ -62,12 +64,8 @@ class Command(BaseCommand):
             print()
             return
 
-        target_semesters = self._get_target_semesters({
-            "use_default_semester": use_default_semester,
-            "year": year,
-            "semester": semester,
-            "expand_semester_by": expand_semester_by,
-        })
+        target_semesters = get_target_semesters(use_default_semester, year, semester,
+                                                expand_semester_by)
 
         if target_semesters is None:
             return
@@ -80,37 +78,6 @@ class Command(BaseCommand):
                 "password": password,
                 "encoding": encoding,
             })
-    
-    def _get_target_semesters(self, semester_specification):
-        use_default_semester = semester_specification["use_default_semester"]
-        year = semester_specification["year"]
-        semester = semester_specification["semester"]
-        expand_semester_by = semester_specification["expand_semester_by"]
-
-        if year is not None and semester is not None:
-            target_semester = (year, semester)
-        elif use_default_semester:
-            default_semester = Semester.get_semester_to_default_import()
-            if default_semester is not None:
-                target_semester = (default_semester.year, default_semester.semester)
-            else:
-                print("Failed to load default semester.")
-                return
-        else:
-            print("Target semester not specified. Use --year and --semester, or --use-default-semester")
-            return
-
-        if expand_semester_by is None:
-            offsets = [0]
-        elif expand_semester_by > 0:
-            offsets = range(0, expand_semester_by + 1)
-        else:
-            offsets = range(expand_semester_by, 1)
-
-        return [
-            Semester.get_offsetted_semester(target_semester[0], target_semester[1], o)
-            for o in offsets
-        ]
 
     def _import_scholardb(self, target_year, target_semester, exclude_lecture, db_specification):
         print(f"Importing scholardb for {target_year}-{target_semester}")

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -35,7 +35,10 @@ class Command(BaseCommand):
                             dest="use_default_semester")
         parser.add_argument("--year", dest="year", type=int)
         parser.add_argument("--semester", dest="semester", type=int)
-        parser.add_argument("--expand-semester-by", dest="expand_semester_by", type=int)
+        parser.add_argument("--expand-semester-by",
+                            dest="expand_semester_by",
+                            type=int,
+                            choices=range(-4, 5))
 
     help = "Imports KAIST scholar database."
     args = "--host=143.248.X.Y:PORT --user=USERNAME"
@@ -67,9 +70,6 @@ class Command(BaseCommand):
 
         if expand_semester_by is None:
             offsets = [0]
-        elif abs(expand_semester_by) > 4:
-            print("Too big number for --expand-semester-by is given. -4 to 4 is allowed")
-            return
         elif expand_semester_by > 0:
             offsets = range(0, expand_semester_by + 1)
         else:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -86,8 +86,8 @@ class Command(BaseCommand):
             print()
             return
 
-        for s in target_semesters:
-            self._import_scholardb(s[0], s[1], exclude_lecture, {
+        for y, s in target_semesters:
+            self._import_scholardb(y, s, exclude_lecture, {
                 "host": host,
                 "port": port,
                 "user": user,

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -144,13 +144,13 @@ class Command(BaseCommand):
             for lecture in Lecture.objects.filter(year=target_year, semester=target_semester):
                 lectures_not_updated.add(lecture.id)
             # Make Staff Professor with ID 830
-            try:
-                staff_professor = Professor.objects.get(professor_id=Professor.STAFF_ID)
-            except Professor.DoesNotExist:
-                staff_professor = Professor.objects.create(professor_id=Professor.STAFF_ID)
-                staff_professor.professor_name = "Staff"
-                staff_professor.professor_name_en = "Staff"
-                staff_professor.save()
+            staff_professor, _ = Professor.objects.get_or_create(
+                professor_id=Professor.STAFF_ID,
+                defaults={
+                    "professor_name": "Staff",
+                    "professor_name_en": "Staff",
+                }
+            )
 
             prev_department = None
             for row in lecture_rows:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -60,6 +60,7 @@ class Command(BaseCommand):
                 target_semester = (default_semester.year, default_semester.semester)
             else:
                 print("Failed to load default semester.")
+                return
         else:
             print("Target semester not specified. Use --year and --semester, or --use-default-semester")
             return

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -106,8 +106,6 @@ class Command(BaseCommand):
         rx_dept_code = re.compile(r"([a-zA-Z]+)(\d+)")
         lecture_count = 0
 
-        return
-
         if not exclude_lecture:
             query = "SELECT * FROM view_OTL_charge WHERE lecture_year = %d AND lecture_term = %d" % (
                 target_year,

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -126,9 +126,9 @@ class Command(BaseCommand):
                 lectures_not_updated.add(lecture.id)
             # Make Staff Professor with ID 830
             try:
-                staff_professor = Professor.objects.get(professor_id=830)
+                staff_professor = Professor.objects.get(professor_id=Professor.STAFF_ID)
             except Professor.DoesNotExist:
-                staff_professor = Professor.objects.create(professor_id=830)
+                staff_professor = Professor.objects.create(professor_id=Professor.STAFF_ID)
                 staff_professor.professor_name = "Staff"
                 staff_professor.professor_name_en = "Staff"
                 staff_professor.save()
@@ -275,13 +275,13 @@ class Command(BaseCommand):
                             else:
                                 prof_major = i[4]
                             professor = Professor.objects.get(professor_id=prof_id)
-                            if professor.professor_name != prof_name and prof_id != 830:
+                            if professor.professor_name != prof_name and prof_id != Professor.STAFF_ID:
                                 professor.professor_name = prof_name
                                 professor.save()
-                            if professor.professor_name_en != prof_name_en and prof_id != 830 and prof_name_en != "":
+                            if professor.professor_name_en != prof_name_en and prof_id != Professor.STAFF_ID and prof_name_en != "":
                                 professor.professor_name_en = prof_name_en
                                 professor.save()
-                            if professor.major != prof_major and prof_id != 830:
+                            if professor.major != prof_major and prof_id != Professor.STAFF_ID:
                                 professor.major = prof_major
                                 professor.save()
                             professors_not_updated.remove(professor.id)
@@ -295,7 +295,7 @@ class Command(BaseCommand):
                         except KeyError:
                             pass
                         lecture.professors.add(professor)
-                        if professor.professor_id != 830:
+                        if professor.professor_id != Professor.STAFF_ID:
                             lecture.course.professors.add(professor)
 
                     for key in professors_not_updated:

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -55,6 +55,38 @@ class Command(BaseCommand):
         semester = options.get("semester", None)
         expand_semester_by = options.get("expand_semester_by", None)
 
+        try:
+            if password is None:
+                password = getpass.getpass()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+
+        target_semesters = self._get_target_semesters({
+            "use_default_semester": use_default_semester,
+            "year": year,
+            "semester": semester,
+            "expand_semester_by": expand_semester_by,
+        })
+
+        if target_semesters is None:
+            return
+
+        for y, s in target_semesters:
+            self._import_scholardb(y, s, exclude_lecture, {
+                "host": host,
+                "port": port,
+                "user": user,
+                "password": password,
+                "encoding": encoding,
+            })
+    
+    def _get_target_semesters(self, semester_specification):
+        use_default_semester = semester_specification["use_default_semester"]
+        year = semester_specification["year"]
+        semester = semester_specification["semester"]
+        expand_semester_by = semester_specification["expand_semester_by"]
+
         if year is not None and semester is not None:
             target_semester = (year, semester)
         elif use_default_semester:
@@ -74,26 +106,11 @@ class Command(BaseCommand):
             offsets = range(0, expand_semester_by + 1)
         else:
             offsets = range(expand_semester_by, 1)
-        target_semesters = [
+
+        return [
             Semester.get_offsetted_semester(target_semester[0], target_semester[1], o)
             for o in offsets
         ]
-
-        try:
-            if password is None:
-                password = getpass.getpass()
-        except (KeyboardInterrupt, EOFError):
-            print()
-            return
-
-        for y, s in target_semesters:
-            self._import_scholardb(y, s, exclude_lecture, {
-                "host": host,
-                "port": port,
-                "user": user,
-                "password": password,
-                "encoding": encoding,
-            })
 
     def _import_scholardb(self, target_year, target_semester, exclude_lecture, db_specification):
         print(f"Importing scholardb for {target_year}-{target_semester}")

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -279,7 +279,7 @@ class Command(BaseCommand):
                 ))
                 if len(match_scholar) != 0:
                     professors_not_updated = set()
-                    for prof in lecture.professor_lecture_charge_rows.all():
+                    for prof in lecture.professor.all():
                         professors_not_updated.add(prof.id)
                     for i in match_scholar:
                         try:
@@ -313,15 +313,15 @@ class Command(BaseCommand):
                         #                            print "Making new Professor ... %s" % professor.professor_name
                         except KeyError:
                             pass
-                        lecture.professor_lecture_charge_rows.add(professor)
+                        lecture.professor.add(professor)
                         if professor.professor_id != Professor.STAFF_ID:
                             lecture.course.professor_lecture_charge_rows.add(professor)
 
                     for key in professors_not_updated:
                         professor = Professor.objects.get(id=key)
-                        lecture.professor_lecture_charge_rows.remove(professor)
+                        lecture.professor.remove(professor)
                 else:
-                    lecture.professor_lecture_charge_rows.add(staff_professor)
+                    lecture.professor.add(staff_professor)
 
                 try:
                     lectures_not_updated.remove(lecture_key_hashable)

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -246,7 +246,7 @@ class Command(BaseCommand):
                 ))
                 if len(match_scholar) != 0:
                     professors_not_updated = set()
-                    for prof in lecture.professor.all():
+                    for prof in lecture.professors.all():
                         professors_not_updated.add(prof.id)
                     for i in match_scholar:
                         try:
@@ -280,15 +280,15 @@ class Command(BaseCommand):
                         #                            print "Making new Professor ... %s" % professor.professor_name
                         except KeyError:
                             pass
-                        lecture.professor.add(professor)
+                        lecture.professors.add(professor)
                         if professor.professor_id != Professor.STAFF_ID:
                             lecture.course.professor_lecture_charge_rows.add(professor)
 
                     for key in professors_not_updated:
                         professor = Professor.objects.get(id=key)
-                        lecture.professor.remove(professor)
+                        lecture.professors.remove(professor)
                 else:
-                    lecture.professor.add(staff_professor)
+                    lecture.professors.add(staff_professor)
 
                 try:
                     lectures_not_updated.remove(lecture_key_hashable)

--- a/apps/subject/management/commands/import-scholardb.py
+++ b/apps/subject/management/commands/import-scholardb.py
@@ -66,6 +66,9 @@ class Command(BaseCommand):
 
         if expand_semester_by is None:
             offsets = [0]
+        elif abs(expand_semester_by) > 4:
+            print("Too big number for --expand-semester-by is given. -4 to 4 is allowed")
+            return
         elif expand_semester_by > 0:
             offsets = range(0, expand_semester_by + 1)
         else:

--- a/apps/subject/management/commands/import-taken-lecture-user.py
+++ b/apps/subject/management/commands/import-taken-lecture-user.py
@@ -54,8 +54,9 @@ class Command(BaseCommand):
             if (a[0], a[1]) not in cleared_semester_list:
                 cleared_semester_list.append((a[0], a[1]))
                 userprofile.taken_lectures.remove(*userprofile.taken_lectures.filter(year=a[0], semester=a[1]))
-            lecture = lectures.filter(year=a[0], semester=a[1], code=a[2], class_no=a[3].strip())
-            if len(lecture) == 1:
-                userprofile.taken_lectures.add(lecture[0])
-            else:
-                print(f"{str(a[0])} {str(a[1])} {a[2]} {a[3]}는 왜 개수가 {len(lecture)} 지?", file=sys.stderr)
+            try:
+                lecture = lectures.get(year=a[0], semester=a[1], code=a[2], class_no=a[3].strip())
+                userprofile.taken_lectures.add(lecture)
+            except (Lecture.DoesNotExist, Lecture.MultipleObjectsReturned) as exception:
+                print(f"error on getting lecture for {str(a[0])} {str(a[1])} {a[2]} {a[3]}", file=sys.stderr)
+                print(exception, file=sys.stderr)

--- a/apps/subject/management/commands/import-taken-lecture-user.py
+++ b/apps/subject/management/commands/import-taken-lecture-user.py
@@ -55,7 +55,7 @@ class Command(BaseCommand):
                 cleared_semester_list.append((a[0], a[1]))
                 userprofile.taken_lectures.remove(*userprofile.taken_lectures.filter(year=a[0], semester=a[1]))
             try:
-                lecture = lectures.get(year=a[0], semester=a[1], code=a[2], class_no=a[3].strip())
+                lecture = lectures.get(year=a[0], semester=a[1], code=a[2], class_no=a[3].strip(), deleted=False)
                 userprofile.taken_lectures.add(lecture)
             except (Lecture.DoesNotExist, Lecture.MultipleObjectsReturned) as exception:
                 print(f"error on getting lecture for {str(a[0])} {str(a[1])} {a[2]} {a[3]}", file=sys.stderr)

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
                             dest="use_default_semester")
         parser.add_argument("--year", dest="year", help="")
         parser.add_argument("--semester", dest="semester", help="")
+        parser.add_argument("--expand-semester-by", dest="expand_semester_by", type=int)
         parser.add_argument("--password", dest="password", help="Specifies passowrd to log in.")
         parser.add_argument(
             "--encoding",
@@ -38,18 +39,30 @@ class Command(BaseCommand):
         use_default_semester = options.get("use_default_semester")
         year = options.get("year", None)
         semester = options.get("semester", None)
+        expand_semester_by = options.get("expand_semester_by", None)
 
         if year is not None and semester is not None:
-            target_semesters = [(year, semester)]
+            target_semester = (year, semester)
         elif use_default_semester:
             default_semester = Semester.get_semester_to_default_import()
             if default_semester is not None:
-                target_semesters = [(default_semester.year, default_semester.semester)]
+                target_semester = (default_semester.year, default_semester.semester)
             else:
                 print("Failed to load default semester.")
         else:
             print("Target semester not specified. Use --year and --semester, or --use-default-semester")
             return
+
+        if expand_semester_by is None:
+            offsets = [0]
+        elif expand_semester_by > 0:
+            offsets = range(0, expand_semester_by + 1)
+        else:
+            offsets = range(expand_semester_by, 1)
+        target_semesters = [
+            Semester.get_offsetted_semester(target_semester[0], target_semester[1], o)
+            for o in offsets
+        ]
 
         try:
             if password is None:

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -123,8 +123,9 @@ class Command(BaseCommand):
                 if u not in cleared_user_list:
                     cleared_user_list.append(u)
                     u.taken_lectures.remove(*u.taken_lectures.filter(year=target_year, semester=target_semester))
-                lecture = lectures.filter(code=a[2], class_no=a[3].strip())
-                if len(lecture) == 1:
-                    u.taken_lectures.add(lecture[0])
-                else:
-                    print(f"{str(a[0])} {str(a[1])} {a[2]} {a[3]}는 왜 개수가 {len(lecture)} 지?", file=sys.stderr)
+                try:
+                    lecture = lectures.get(code=a[2], class_no=a[3].strip())
+                    u.taken_lectures.add(lecture)
+                except (Lecture.DoesNotExist, Lecture.MultipleObjectsReturned) as exception:
+                    print(f"error on getting lecture for {str(a[0])} {str(a[1])} {a[2]} {a[3]}", file=sys.stderr)
+                    print(exception, file=sys.stderr)

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -75,8 +75,8 @@ class Command(BaseCommand):
             print()
             return
 
-        for s in target_semesters:
-            self._import_taken_lecture(s[0], s[1], {
+        for y, s in target_semesters:
+            self._import_taken_lecture(y, s, {
                 "host": host,
                 "port": port,
                 "user": user,

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -124,7 +124,7 @@ class Command(BaseCommand):
                     cleared_user_list.append(u)
                     u.taken_lectures.remove(*u.taken_lectures.filter(year=target_year, semester=target_semester))
                 try:
-                    lecture = lectures.get(code=a[2], class_no=a[3].strip())
+                    lecture = lectures.get(code=a[2], class_no=a[3].strip(), deleted=False)
                     u.taken_lectures.add(lecture)
                 except (Lecture.DoesNotExist, Lecture.MultipleObjectsReturned) as exception:
                     print(f"error on getting lecture for {str(a[0])} {str(a[1])} {a[2]} {a[3]}", file=sys.stderr)

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -49,6 +49,7 @@ class Command(BaseCommand):
                 target_semester = (default_semester.year, default_semester.semester)
             else:
                 print("Failed to load default semester.")
+                return
         else:
             print("Target semester not specified. Use --year and --semester, or --use-default-semester")
             return

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -3,6 +3,8 @@ import sys
 import getpass
 from django.core.management.base import BaseCommand
 
+from utils.command_utils import get_target_semesters
+
 from apps.subject.models import Semester, Lecture
 from apps.session.models import UserProfile
 
@@ -51,12 +53,8 @@ class Command(BaseCommand):
             print()
             return
 
-        target_semesters = self._get_target_semesters({
-            "use_default_semester": use_default_semester,
-            "year": year,
-            "semester": semester,
-            "expand_semester_by": expand_semester_by,
-        })
+        target_semesters = get_target_semesters(use_default_semester, year, semester,
+                                                expand_semester_by)
 
         if target_semesters is None:
             return
@@ -69,38 +67,6 @@ class Command(BaseCommand):
                 "password": password,
                 "encoding": encoding,
             })
-    
-    def _get_target_semesters(self, semester_specification):
-        use_default_semester = semester_specification["use_default_semester"]
-        year = semester_specification["year"]
-        semester = semester_specification["semester"]
-        expand_semester_by = semester_specification["expand_semester_by"]
-
-        if year is not None and semester is not None:
-            target_semester = (year, semester)
-        elif use_default_semester:
-            default_semester = Semester.get_semester_to_default_import()
-            if default_semester is not None:
-                target_semester = (default_semester.year, default_semester.semester)
-            else:
-                print("Failed to load default semester.")
-                return
-        else:
-            print("Target semester not specified. Use --year and --semester, or --use-default-semester")
-            return
-
-        if expand_semester_by is None:
-            offsets = [0]
-        elif expand_semester_by > 0:
-            offsets = range(0, expand_semester_by + 1)
-        else:
-            offsets = range(expand_semester_by, 1)
-
-        return [
-            Semester.get_offsetted_semester(target_semester[0], target_semester[1], o)
-            for o in offsets
-        ]
-
 
     def _import_taken_lecture(self, target_year, target_semester, db_specification):
         print(target_year, target_semester)

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -55,6 +55,9 @@ class Command(BaseCommand):
 
         if expand_semester_by is None:
             offsets = [0]
+        elif abs(expand_semester_by) > 4:
+            print("Too big number for --expand-semester-by is given. -4 to 4 is allowed")
+            return
         elif expand_semester_by > 0:
             offsets = range(0, expand_semester_by + 1)
         else:

--- a/apps/subject/management/commands/import-taken-lecture.py
+++ b/apps/subject/management/commands/import-taken-lecture.py
@@ -18,7 +18,10 @@ class Command(BaseCommand):
                             dest="use_default_semester")
         parser.add_argument("--year", dest="year", help="")
         parser.add_argument("--semester", dest="semester", help="")
-        parser.add_argument("--expand-semester-by", dest="expand_semester_by", type=int)
+        parser.add_argument("--expand-semester-by",
+                            dest="expand_semester_by",
+                            type=int,
+                            choices=range(-4, 5))
         parser.add_argument("--password", dest="password", help="Specifies passowrd to log in.")
         parser.add_argument(
             "--encoding",
@@ -56,9 +59,6 @@ class Command(BaseCommand):
 
         if expand_semester_by is None:
             offsets = [0]
-        elif abs(expand_semester_by) > 4:
-            print("Too big number for --expand-semester-by is given. -4 to 4 is allowed")
-            return
         elif expand_semester_by > 0:
             offsets = range(0, expand_semester_by + 1)
         else:

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -83,7 +83,9 @@ class Semester(models.Model):
 
     @classmethod
     def get_offsetted_semester(cls, original_year: int, original_semester: int, offset: int):
-        # TODO: Change to receive and return Semester after adding summer/winter semester
+        # TODO: Change to receive and return Semester class instance instead of
+        #       integer type year and semester value
+        #       See issue #845
         temp_semester = original_semester + offset
         year_diff = (temp_semester - 1) // 4
 

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -1,5 +1,6 @@
 from datetime import time
 from functools import reduce
+from typing import Tuple
 import operator
 import datetime
 
@@ -81,17 +82,32 @@ class Semester(models.Model):
         return cls.objects.filter(courseDesciptionSubmission__lt=now) \
                           .order_by("courseDesciptionSubmission").last()
 
-    @classmethod
-    def get_offsetted_semester(cls, original_year: int, original_semester: int, offset: int):
-        # TODO: Change to receive and return Semester class instance instead of
-        #       integer type year and semester value
-        #       See issue #845
-        temp_semester = original_semester + offset
-        year_diff = (temp_semester - 1) // 4
+    # TODO: Change methods below to receive and return Semester class instance instead of
+    #       integer type year and semester value
+    #       See issue #845
 
-        new_year = original_year + year_diff
-        new_semester = temp_semester - year_diff * 4
-        return new_year, new_semester
+    @classmethod
+    def get_prev_semester(cls, year: int, semester: int) -> Tuple[int, int]:
+        if semester == 1:
+            return year - 1, 4
+        else:
+            return year, semester - 1
+
+    @classmethod
+    def get_next_semester(cls, year: int, semester: int) -> Tuple[int, int]:
+        if semester == 4:
+            return year + 1, 1
+        else:
+            return year, semester + 1
+
+    @classmethod
+    def get_offsetted_semester(cls, year: int, semester: int, offset: int) -> Tuple[int, int]:
+        for _ in range(abs(offset)):
+            if offset > 0:
+                year, semester = Semester.get_next_semester(year, semester)
+            else:
+                year, semester = Semester.get_prev_semester(year, semester)
+        return year, semester
 
 
 class Lecture(models.Model):

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -603,6 +603,8 @@ class Course(models.Model):
 
 
 class Professor(models.Model):
+    STAFF_ID = 830
+
     # Fetched from KAIST Scholar DB
     professor_name = models.CharField(max_length=100, db_index=True)
     professor_name_en = models.CharField(max_length=100, blank=True, null=True)

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -82,16 +82,13 @@ class Semester(models.Model):
                           .order_by("courseDesciptionSubmission").last()
 
     @classmethod
-    def get_offsetted_semester(cls, semester: "Semester", offset: int):
-        original_year = semester.year
-        original_semester = semester.semester
-
+    def get_offsetted_semester(cls, original_year: int, original_semester: int, offset: int):
+        # TODO: Change to get and resturn Semester after adding summer/winter semester
         temp_semester = original_semester + offset
         year_diff = (temp_semester - 1) // 4
 
         new_year = original_year + year_diff
         new_semester = temp_semester - year_diff * 4
-        # TODO: Change to resturn Semester after adding summer/winter semester
         return new_year, new_semester
 
 

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -81,6 +81,19 @@ class Semester(models.Model):
         return cls.objects.filter(courseDesciptionSubmission__lt=now) \
                           .order_by("courseDesciptionSubmission").last()
 
+    @classmethod
+    def get_offsetted_semester(cls, semester: "Semester", offset: int):
+        original_year = semester.year
+        original_semester = semester.semester
+
+        temp_semester = original_semester + offset
+        year_diff = (temp_semester - 1) // 4
+
+        new_year = original_year + year_diff
+        new_semester = temp_semester - year_diff * 4
+        # TODO: Change to resturn Semester after adding summer/winter semester
+        return new_year, new_semester
+
 
 class Lecture(models.Model):
     # Fetched from KAIST Scholar DB

--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -83,7 +83,7 @@ class Semester(models.Model):
 
     @classmethod
     def get_offsetted_semester(cls, original_year: int, original_semester: int, offset: int):
-        # TODO: Change to get and resturn Semester after adding summer/winter semester
+        # TODO: Change to receive and return Semester after adding summer/winter semester
         temp_semester = original_semester + offset
         year_diff = (temp_semester - 1) // 4
 

--- a/utils/command_utils.py
+++ b/utils/command_utils.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+
+from apps.subject.models import Semester
+
+def get_target_semesters(use_default_semester: bool, year: int, semester: int,
+                         expand_semester_by: int) -> Optional[List[Semester]]:
+
+    if year is not None and semester is not None:
+        target_semester = (year, semester)
+    elif use_default_semester:
+        default_semester = Semester.get_semester_to_default_import()
+        if default_semester is not None:
+            target_semester = (default_semester.year, default_semester.semester)
+        else:
+            print("Failed to load default semester.")
+            return
+    else:
+        print("Target semester not specified. Use --year and --semester, or --use-default-semester")
+        return
+
+    if expand_semester_by is None:
+        offsets = [0]
+    elif expand_semester_by > 0:
+        offsets = range(0, expand_semester_by + 1)
+    else:
+        offsets = range(expand_semester_by, 1)
+
+    return [
+        Semester.get_offsetted_semester(target_semester[0], target_semester[1], o)
+        for o in offsets
+    ]


### PR DESCRIPTION
계절학기 과목이 자동으로 업데이트되지 않는 문제를 해결하기 위한 수정사항입니다.

- 기존 --year과 --semester이 주어지지 않으면 자동으로 기본 학기를 대상으로 하던 것을 --use-default-semester을 추가해 명시적으로 선언하게 변경
  - --year, --semester, --use-default-semester 중 아무것도 주어지지 않으면 command가 실행되지 않게 변경
- --expand-semester-by 옵션 추가. 명시된 학기에서 해당 offset만큼 사이에 해당되는(inclusive, 오름차순) 모든 학기에 대해 import를 실행함.

자동으로 매일 돌아가는 스크립트는 '--use-default-semester --expand-semester-by=-1' 로 돌아갈 예정입니다.
--expand-semester-by가 -1인 이유는 계절학기가 시작되기 전 그 다음 정규학기로 default-semester가 넘어가기 떄문입니다.