### PR TITLE
Changed arrow selector condition from orientation to hover

### DIFF
--- a/react/src/components/sections/timetable/LectureDetailSection.js
+++ b/react/src/components/sections/timetable/LectureDetailSection.js
@@ -44,6 +44,7 @@ class LectureDetailSection extends Component {
     super(props);
     this.state = {
       shouldShowCloseDict: false,
+      isReviewLoading: false,
     };
 
     // eslint-disable-next-line fp/no-mutation
@@ -65,11 +66,15 @@ class LectureDetailSection extends Component {
     }
     if ((prevProps.lectureFocus.lecture && lectureFocus.lecture)
       && (prevProps.lectureFocus.lecture.id !== lectureFocus.lecture.id)) {
+      this._resetIsReviewLoading();
       this._checkAndLoadReviews();
     }
     if ((prevProps.lectureFocus.lecture && lectureFocus.lecture)
       && (prevProps.lectureFocus.clicked !== lectureFocus.clicked)) {
       this._checkAndLoadReviews();
+    }
+    if (prevProps.lectureFocus.lecture && !lectureFocus.lecture) {
+      this._resetIsReviewLoading();
     }
 
     if (prevProps.lectureFocus.clicked && lectureFocus.clicked) {
@@ -101,6 +106,12 @@ class LectureDetailSection extends Component {
     else if ((prevProps.year !== year) || (prevProps.semester !== semester)) {
       clearLectureFocusDispatch();
     }
+  }
+
+  _resetIsReviewLoading = () => {
+    this.setState({
+      isReviewLoading: false,
+    });
   }
 
   openDictPreview = () => {
@@ -286,9 +297,10 @@ class LectureDetailSection extends Component {
   _checkAndLoadReviews = () => {
     const LIMIT = 100;
 
+    const { isReviewLoading } = this.state;
     const { lectureFocus, setReviewsDispatch } = this.props;
 
-    if (lectureFocus.reviews !== null) {
+    if (isReviewLoading || (lectureFocus.reviews !== null)) {
       return;
     }
 
@@ -303,6 +315,9 @@ class LectureDetailSection extends Component {
       return;
     }
 
+    this.setState({
+      isReviewLoading: true,
+    });
     axios.get(
       `/api/lectures/${lectureFocus.lecture.id}/related-reviews`,
       {
@@ -324,6 +339,9 @@ class LectureDetailSection extends Component {
         if (response.data === LIMIT) {
           // TODO: handle limit overflow
         }
+        this.setState({
+          isReviewLoading: false,
+        });
         setReviewsDispatch(response.data);
       })
       .catch((error) => {

--- a/react/src/components/sections/timetable/LectureListSection.js
+++ b/react/src/components/sections/timetable/LectureListSection.js
@@ -238,8 +238,13 @@ class LectureListSection extends Component {
   selectWithArrow = () => {
     const {
       lists, selectedListCode,
+      lectureFocus,
       clearLectureFocusDispatch, setLectureFocusDispatch,
     } = this.props;
+
+    if (lectureFocus.clicked) {
+      return;
+    }
 
     const arrow = this.arrowRef.current;
     const arrowPosition = (this.arrowRef.current).getBoundingClientRect();
@@ -417,7 +422,13 @@ class LectureListSection extends Component {
           { ((selectedListCode === LectureListCode.SEARCH) && searchOpen) ? <LectureSearchSubSection /> : null }
           <CloseButton onClick={this.mobileCloseLectureList} />
           { getListTitle() }
-          <div className={classNames('subsection--lecture-list__selector')} ref={this.arrowRef}>
+          <div
+            className={classNames(
+              'subsection--lecture-list__selector',
+              (lectureFocus.clicked ? 'subsection--lecture-list__selector--dimmed' : null),
+            )}
+            ref={this.arrowRef}
+          >
             <i className={classNames('icon', 'icon--lecture-selector')} />
           </div>
           { getListElement() }

--- a/react/src/components/sections/timetable/LectureListSection.js
+++ b/react/src/components/sections/timetable/LectureListSection.js
@@ -248,6 +248,7 @@ class LectureListSection extends Component {
 
     const arrow = this.arrowRef.current;
     const arrowPosition = (this.arrowRef.current).getBoundingClientRect();
+    const arrowX = arrowPosition.left;
     const arrowY = (arrowPosition.top + arrowPosition.bottom) / 2;
 
     if (window.getComputedStyle(arrow).getPropertyValue('display') === 'none'
@@ -256,9 +257,9 @@ class LectureListSection extends Component {
     }
 
     const elementAtPosition = (
-      document.elementFromPoint(100, arrowY).closest(`.${classNames('block--lecture-group__row')}`)
-      || document.elementFromPoint(100, arrowY - 25).closest(`.${classNames('block--lecture-group__row')}`)
-      || document.elementFromPoint(100, arrowY + 25).closest(`.${classNames('block--lecture-group__row')}`)
+      document.elementFromPoint(arrowX - 15, arrowY).closest(`.${classNames('block--lecture-group__row')}`)
+      || document.elementFromPoint(arrowX - 15, arrowY - 25).closest(`.${classNames('block--lecture-group__row')}`)
+      || document.elementFromPoint(arrowX - 15, arrowY + 25).closest(`.${classNames('block--lecture-group__row')}`)
     );
     if (elementAtPosition === null) {
       clearLectureFocusDispatch();

--- a/react/src/styles/App.module.scss
+++ b/react/src/styles/App.module.scss
@@ -917,6 +917,10 @@ a {
             @media #{$media-no-hover} {
                 display: initial;
             }
+
+            &--dimmed {
+                opacity: 0.3;
+            }
         }
 
         & > div:last-child {

--- a/react/src/styles/App.module.scss
+++ b/react/src/styles/App.module.scss
@@ -95,6 +95,7 @@ $score-line-height-mobile: calc(#{$score-font-size-mobile} - 2px);
 
 $media-landscape: (min-aspect-ratio: 4/3);
 $media-portrait: (max-aspect-ratio: 4/3);
+$media-no-hover: (hover: none);
 
 $section-width-desktop-1v3-left: calc(15vh + 126px);
 $section-height-desktop-lecture-detail: calc(
@@ -912,13 +913,14 @@ a {
             position: absolute;
             top: calc((100% + #{$line-height-big} + #{$list-title-margin-bottom} - 12px) / 2);
             right: #{$section-padding};
-            @media #{$media-landscape} {
-                display: none;
+            display: none;
+            @media #{$media-no-hover} {
+                display: initial;
             }
         }
 
         & > div:last-child {
-            @media #{$media-portrait} {
+            @media #{$media-no-hover} {
                 .block--lecture-group {
                     margin-right: 6px + 10px;
                     &:first-child {
@@ -1995,7 +1997,7 @@ a {
                     line-height: $line-height-smaller;
                     color: $color-text-lighter;
                     display: none;
-                    @media #{$media-portrait} {
+                    @media #{$media-no-hover} {
                         @at-root
                         .block--lecture-group__row--highlighted #{&} {
                             display: block;

--- a/react/src/styles/App.module.scss
+++ b/react/src/styles/App.module.scss
@@ -2023,6 +2023,11 @@ a {
                 @media #{$media-portrait} {
                     display: none;
                 }
+                @media #{$media-no-hover} {
+                    .block--lecture-group__row:not(.block--lecture-group__row--highlighted) & {
+                        display: none;
+                    }
+                }
 
                 &--disable {
                     pointer-events: none;


### PR DESCRIPTION
모의시간표 과목 리스트의 화살표는 모바일 기기에서 hover 인터랙션이 없는 것을 보완하기 위해 만들어졌습니다.
하지만 이것이 hover 여부가 아닌 화면 비율에 의해 결정되었기에 portrait이지만 hover가 있는 경우(데스크탑에서 세로로 길게 창을 띄운 경우 등)와 landscape이지만 hover가 없는 경우(태블릿 등)에는 불편함이 있었습니다.
이것을 hover media query롤 통해 해결합니다.