### PR TITLE
과목명으로 검색할 경우 공백 무시

### DIFF
--- a/apps/subject/services.py
+++ b/apps/subject/services.py
@@ -1,7 +1,8 @@
 import datetime
 from typing import List, Dict, Optional
 
-from django.db.models import Q, QuerySet
+from django.db.models import Q, QuerySet, Value
+from django.db.models.functions import Replace
 from django.http import QueryDict
 from django.utils import timezone
 
@@ -117,13 +118,17 @@ def filter_by_keyword(queryset: QuerySet, keyword: Optional[str]) -> QuerySet:
         return queryset
 
     keyword = keyword.strip()
+    keyword_space_removed = keyword.replace(' ', '')
 
     if len(keyword) == 0:
         return queryset
 
-    return queryset.filter(
-        Q(title__icontains=keyword)
-        | Q(title_en__icontains=keyword)
+    return queryset.annotate(
+        title_space_removed=Replace('title', Value(' '), Value('')),
+        title_en_space_removed=Replace('title_en', Value(' '), Value(''))
+    ).filter(
+        Q(title_space_removed__icontains=keyword_space_removed)
+        | Q(title_en_space_removed__icontains=keyword_space_removed)
         | Q(old_code__istartswith=keyword)
         | Q(department__name__iexact=keyword)
         | Q(department__name_en__iexact=keyword)


### PR DESCRIPTION
[관련 기능 제안](https://www.notion.so/sparcs/b197104d009d43fb831bc90f368f88ff)

## 기존
기존 검색에서는 띄어쓰기 있는 과목의 경우 띄어쓰기를 포함해야 검색 결과에 포함됨.
예를 들어 `알고리즘 개론`은 `알고리즘개론`으로는 검색되지 않음.

## 변경사항
`queryset.annotate`함수를 사용해 (SQL의 REPLACE를 대신해) 컬럼값의 공백을 무시하고 `keyword`의 공백도 제거.
이후 annotated column값을 `icontains`를 이용해 검색하는 것으로 변경. ([참고](https://stackoverflow.com/a/66999785/14193566))

## 테스트(좌측: 변경 이후/우측: 기존)
![change](https://user-images.githubusercontent.com/34625313/159065199-1daee8cd-75b5-496c-9103-aa07c7e0a4a1.png)
![change-en](https://user-images.githubusercontent.com/34625313/159065215-1e2345ba-def2-46f4-8d7b-5941b3c4acaf.png)
