### PR TITLE
fix: 인문사회선택 과목구분 변경 대응

### DIFF
--- a/apps/main/models.py
+++ b/apps/main/models.py
@@ -81,7 +81,7 @@ class FamousHumanityReviewDailyFeed(DailyFeed):
         try:
             feed = cls.objects.get(date=date)
         except cls.DoesNotExist:
-            reviews = HumanityBestReview.objects.filter(review__lecture__type_en=
+            reviews = HumanityBestReview.objects.filter(review__lecture__type_en__startswith=
                                                         "Humanities & Social Elective")
             if reviews.count() < 3:
                 selected_reviews = reviews[:]

--- a/apps/subject/services.py
+++ b/apps/subject/services.py
@@ -1,4 +1,6 @@
 import datetime
+import functools
+import operator
 from typing import List, Dict, Optional
 
 from django.db.models import Q, QuerySet, Value
@@ -61,10 +63,14 @@ def filter_by_type(queryset: QuerySet, types: List[str]) -> QuerySet:
         return queryset
     elif "ETC" in types:
         unselected_types = [TYPE_ACRONYMS[x] for x in TYPE_ACRONYMS if x not in types]
-        return queryset.exclude(type_en__in=unselected_types)
+        return queryset.exclude(
+            functools.reduce(operator.and_, (Q(type_en__startswith=t) for t in unselected_types))
+        )
     else:
         selected_types = [TYPE_ACRONYMS[x] for x in TYPE_ACRONYMS if x in types]
-        return queryset.filter(type_en__in=selected_types)
+        return queryset.filter(
+            functools.reduce(operator.and_, (Q(type_en__startswith=t) for t in selected_types))
+        )
 
 
 def filter_by_level(queryset: QuerySet, levels: Optional[List[str]]) -> QuerySet:

--- a/apps/subject/services.py
+++ b/apps/subject/services.py
@@ -106,7 +106,7 @@ def filter_by_group(queryset: QuerySet, group: Optional[List[str]]) -> QuerySet:
         query |= Q(type_en__in=filter_type)
     if "Humanity" in group:
         group.remove("Humanity")
-        query |= Q(type_en="Humanities & Social Elective")
+        query |= Q(type_en__startswith="Humanities & Social Elective")
     if len(group) > 0:
         filter_type = ["Major Required", "Major Elective", "Elective(Graduate)"]
         query |= Q(type_en__in=filter_type, department__code__in=group)

--- a/react/src/components/sections/timetable/SummarySubSection.js
+++ b/react/src/components/sections/timetable/SummarySubSection.js
@@ -22,7 +22,7 @@ import Scores from '../../Scores';
 const TAGET_TYPES = ['Basic Required', 'Basic Elective', 'Major Required', 'Major Elective', 'Humanities & Social Elective'];
 
 const indexOfType = (type) => {
-  const index = TAGET_TYPES.indexOf(type);
+  const index = TAGET_TYPES.findIndex((t) => type.startsWith(t));
   if (index === -1) {
     return 5;
   }


### PR DESCRIPTION
## 21 봄 이후 DB에서 테스트 필요합니다

인문사회선택 과목의 과목 구분이 세분화되어 (ex: `Humanities & Social Elective(Arts-Core)`) 검색 탭에서 먹히지 않는 문제 발생 중.
해당 쿼리에 `startswith` 적용.