### PR TITLE
Modified required Pillow package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ httplib2==0.19.1
 icalendar==4.0.7
 mysqlclient==2.0.3
 oauth2client==4.1.3
-Pillow==9.0.1
+Pillow==8.4.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 pyjade==4.0.0


### PR DESCRIPTION
9.x.x 버전에서 이미지 저장이 정상적으로 되지 않아 임시로 버전을 다운그레이드합니다.
참고: #938 