### PR TITLE
Resolve #978, add caching to serialize result of tracks

### DIFF
--- a/apps/graduation/models.py
+++ b/apps/graduation/models.py
@@ -1,4 +1,5 @@
 from django.db import models
+from django.core.cache import cache
 
 from apps.subject.models import Department
 
@@ -26,7 +27,15 @@ class GeneralTrack(models.Model):
     class Meta:
         unique_together = [["start_year", "is_foreign"], ["end_year", "is_foreign"]]
 
+    def get_cache_key(self):
+        return "generaltrack:%d-%d-%s" % (self.start_year, self.end_year, self.is_foreign)
+
     def to_json(self):
+        cache_id = self.get_cache_key()
+        result_cached = cache.get(cache_id)
+        if result_cached is not None:
+            return result_cached
+
         result = {
             "id": self.id,
             "start_year": self.start_year,
@@ -44,6 +53,8 @@ class GeneralTrack(models.Model):
             "humanities_doublemajor": self.humanities_doublemajor,
         }
 
+        cache.set(cache_id, result, 60 * 60)
+
         return result
 
 
@@ -60,7 +71,15 @@ class MajorTrack(models.Model):
     class Meta:
         unique_together = [["start_year", "department"], ["end_year", "department"]]
 
+    def get_cache_key(self):
+        return "majortrack:%d-%d-%d" % (self.start_year, self.end_year, self.department.id)
+
     def to_json(self):
+        cache_id = self.get_cache_key()
+        result_cached = cache.get(cache_id)
+        if result_cached is not None:
+            return result_cached
+
         result = {
             "id": self.id,
             "start_year": self.start_year,
@@ -70,6 +89,8 @@ class MajorTrack(models.Model):
             "major_required": self.major_required,
             "major_elective": self.major_elective,
         }
+
+        cache.set(cache_id, result, 60 * 60)
 
         return result
 
@@ -95,7 +116,15 @@ class AdditionalTrack(models.Model):
     class Meta:
         unique_together = [["start_year", "type", "department"], ["end_year", "type", "department"]]
 
+    def get_cache_key(self):
+        return "additionaltrack:%d-%d-%s-%d" % (self.start_year, self.end_year, self.type, self.department.id if self.department else 0)
+
     def to_json(self):
+        cache_id = self.get_cache_key()
+        result_cached = cache.get(cache_id)
+        if result_cached is not None:
+            return result_cached
+
         result = {
             "id": self.id,
             "start_year": self.start_year,
@@ -105,5 +134,7 @@ class AdditionalTrack(models.Model):
             "major_required": self.major_required,
             "major_elective": self.major_elective,
         }
+
+        cache.set(cache_id, result, 60 * 60)
 
         return result


### PR DESCRIPTION
기존에 적용되어 있던 캐시 정책은 아래와 같습니다.
1\. Semester, Department 등: 개수가 많지 않으며 거의 변경되지 않기 때문에 60분의 캐시 적용
2-1\. Review: 개수가 많고 비교적 자주 변경될 수 있기 때문에 (내용 수정, 좋아요 모두 포함) 10분의 캐시 적용
2-2\. Lecture, Course 등: 개수가 많고 serialize 결과 크기가 크며, 후기 좋아요에 의해 점수가 변경될 수 있기 때문에 10분의 캐시 적용
3\. Timetable 등: 한 인스턴스를 한 사용자만 접근할 수 있고 자주 수정되기 때문에 (특히 여러 번의 로드 사이에) 캐시 적용하지 않음

신규 모델 중 Track은 1번, Planner와 하위 model은 3번에 해당한다고 판단하였습니다.

참고로 Timetable과 Planner의 경우 전체의 serialize 결과를 캐싱하지 않는 것이며, 이 안에 nest된 Lecture나 Course에 대해서는 캐시에 저장된 결과를 불러옵니다.