### PR TITLE
Fix 학사 DB 접근 (with Xen server), Fix docker compose deployment 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,9 @@
 /.github/
 /.idea/
 
+**/node_modules/
+**/build/
+
 /volumes/db
 
 .pylintrc

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ react/node_modules
 htmlcov/
 
 /volumes/
+/react/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,10 @@ services:
     volumes:
       - ./volumes/db:/var/lib/mysql
       - ./volumes/dump:/dump
-    command: --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: |
+      --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB 
+      --character-set-client=utf8mb4 --character-set-database=utf8mb4 --character-set-server=utf8mb4 
+      --collation-connection=utf8mb4_unicode_ci --collation-server=utf8mb4_unicode_ci
   back:
     depends_on: 
       wait-for-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ services:
       - ./volumes/dump:/dump
     command: |
       --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB 
-      --character-set-client=utf8mb4 --character-set-database=utf8mb4 --character-set-server=utf8mb4 
-      --collation-connection=utf8mb4_unicode_ci --collation-server=utf8mb4_unicode_ci
+      --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
   back:
     depends_on: 
       wait-for-db:

--- a/docker/Dockerfile.back
+++ b/docker/Dockerfile.back
@@ -17,6 +17,7 @@ EXPOSE 8000
 
 ADD ./volumes/config /root/.ssh/config
 ADD ./volumes/key.pem /root/key.pem
-RUN chown -R root:root /root && chmod 400 /root/key.pem && echo "StrictHostKeyChecking no" >> /etc/ssh_config
+ADD ./volumes/wheel-2021.pem /root/wheel-2021.pem
+RUN chown -R root:root /root && chmod 400 /root/key.pem && chmod 400 /root/wheel-2021.pem && echo "StrictHostKeyChecking no" >> /etc/ssh_config
 
 CMD ["gunicorn", "otlplus.wsgi", "--bind", "0.0.0.0:8000"]

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -16,7 +16,10 @@ services:
     volumes:
       - ../volumes/db:/var/lib/mysql
       - ../volumes/dump:/dump
-    command: --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
+    command: |
+      --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB 
+      --character-set-client=utf8mb4 --character-set-database=utf8mb4 --character-set-server=utf8mb4 
+      --collation-connection=utf8mb4_unicode_ci --collation-server=utf8mb4_unicode_ci
   back:
     depends_on: 
       - db

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -12,6 +12,7 @@ services:
       - MYSQL_ROOT_HOSTS=%
       - MYSQL_ROOT_PASSWORD=${OTLPLUS_DB_PASSWORD}
       - MYSQL_DATABASE=otlplus
+      - TZ=Asia/Seoul
     volumes:
       - ../volumes/db:/var/lib/mysql
       - ../volumes/dump:/dump
@@ -30,6 +31,7 @@ services:
       - "58000:8000"
       - "8022:22"
     volumes:
+      - "/etc/timezone:/etc/timezone:ro"
       - ../volumes/scripts:/var/www/otlplus/scripts:ro
       - ../volumes/logs:/var/www/otlplus/logs
     working_dir: /var/www/otlplus

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -28,6 +28,7 @@ services:
     tty: true
     ports:
       - "58000:8000"
+      - "8022:22"
     volumes:
       - ../volumes/scripts:/var/www/otlplus/scripts:ro
       - ../volumes/logs:/var/www/otlplus/logs

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -35,17 +35,3 @@ services:
       - ../volumes/scripts:/var/www/otlplus/scripts:ro
       - ../volumes/logs:/var/www/otlplus/logs
     working_dir: /var/www/otlplus
-  front:
-    container_name: otlplus-front
-    platform: linux/amd64
-    build:
-      context: ..
-      dockerfile: ./docker/Dockerfile.front
-    restart: always
-    tty: true
-    ports:
-      - "58080:80"
-    volumes:
-      - ../volumes/scripts:/var/www/otlplus/scripts:ro
-      - ../volumes/logs:/var/www/otlplus/logs
-    working_dir: /var/www/otlplus/react

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -18,8 +18,7 @@ services:
       - ../volumes/dump:/dump
     command: |
       --sql_mode=NO_ENGINE_SUBSTITUTION --default_storage_engine=InnoDB 
-      --character-set-client=utf8mb4 --character-set-database=utf8mb4 --character-set-server=utf8mb4 
-      --collation-connection=utf8mb4_unicode_ci --collation-server=utf8mb4_unicode_ci
+      --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci
   back:
     depends_on: 
       - db

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -11,6 +11,7 @@ services:
     tty: true
     ports:
       - "58000:8000"
+      - "8022:22"
     volumes:
       - ../volumes/scripts:/var/www/otlplus/scripts:ro
       - ../volumes/logs:/var/www/otlplus/logs

--- a/docker/docker-compose.prod.yml
+++ b/docker/docker-compose.prod.yml
@@ -13,6 +13,7 @@ services:
       - "58000:8000"
       - "8022:22"
     volumes:
+      - "/etc/timezone:/etc/timezone:ro"
       - ../volumes/scripts:/var/www/otlplus/scripts:ro
       - ../volumes/logs:/var/www/otlplus/logs
     working_dir: /var/www/otlplus

--- a/otlplus/settings.py
+++ b/otlplus/settings.py
@@ -95,6 +95,9 @@ DATABASES = {
         'PASSWORD': 'p@ssw0rd',
         'HOST': 'db',
         'PORT': '3306',
+        "OPTIONS": {
+            "charset": "utf8mb4",
+        },
     }
 }
 

--- a/otlplus/settings.py
+++ b/otlplus/settings.py
@@ -97,6 +97,7 @@ DATABASES = {
         'PORT': '3306',
         "OPTIONS": {
             "charset": "utf8mb4",
+            "init_command": "ALTER DATABASE otlplus CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
         },
     }
 }

--- a/otlplus/settings.py
+++ b/otlplus/settings.py
@@ -97,7 +97,6 @@ DATABASES = {
         'PORT': '3306',
         "OPTIONS": {
             "charset": "utf8mb4",
-            "init_command": "ALTER DATABASE otlplus CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci",
         },
     }
 }

--- a/scholardb_access.py
+++ b/scholardb_access.py
@@ -19,12 +19,11 @@ def execute(host, port, user, password, query):
     f.write("%s\n%s\n%s\n%s\n%s" % (host, port, user, password, query))
     f.close()
 
-    os.system("scp -oStrictHostKeyChecking=no -i ~/key.pem -P 8022 /tmp/otl_db_ssh_args wheel@143.248.234.126:/tmp > /dev/null")
+    os.system("scp /tmp/otl_db_ssh_args xen:/tmp > /dev/null")
     os.remove("/tmp/otl_db_ssh_args")
-    os.system(
-        "ssh -oStrictHostKeyChecking=no -i ~/key.pem -p 8022 wheel@143.248.234.126 python db.py > /dev/null")
-    os.system("scp -oStrictHostKeyChecking=no -i ~/key.pem -P 8022 wheel@143.248.234.126:/tmp/otl_db_dump_result /tmp > /dev/null")
-    os.system("ssh -oStrictHostKeyChecking=no -i ~/key.pem -p 8022 wheel@143.248.234.126 rm /tmp/otl_db_dump_result > /dev/null")
+    os.system("ssh xen python db.py > /dev/null")
+    os.system("scp xen:/tmp/otl_db_dump_result /tmp > /dev/null")
+    os.system("ssh xen rm /tmp/otl_db_dump_result > /dev/null")
     result = pickle.load(open("/tmp/otl_db_dump_result", "rb"), encoding="bytes")
     os.remove("/tmp/otl_db_dump_result")
 


### PR DESCRIPTION
- 컨테이너에 불필요한 파일을 .dockerignore 에 추가하였습니다.
- /react 폴더를 .gitignore에 추가하였습니다.
- channeltalk 서버에 접근하기 위한 pem 키 컨테이너 추가
- dev 서버에서 timezone 추가 및 front 컨테이너 제거
- Django settings.py에서 charset 설정 utf8mb4 추가
- 학사DB 접근 방법 channeltalk을 경유하는 올바른 방식으로 수정

현재 front-end react 빌드 컨테이너화를 시도하였으나, RAM 부족으로 추정되는 문제로 도커 컨테이너 내에서 빌드가 되지 않습니다.