### PR TITLE
Add write permission to back container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     ports:
       - "58000:8000"
     volumes:
-      - .:/var/www/otlplus:ro
+      - .:/var/www/otlplus
     working_dir: /var/www/otlplus
   wait-for-db:
     image: atkrad/wait4x


### PR DESCRIPTION
Django command를 사용해서 migration script를 만들 때 권한이 필요합니다