### PR TITLE
chore: remove unnecessary traceback logs

### DIFF
--- a/apps/subject/models.py
+++ b/apps/subject/models.py
@@ -3,7 +3,6 @@ from functools import reduce
 from typing import Tuple
 import operator
 import datetime
-import traceback
 
 from django.core.cache import cache
 from django.db import models
@@ -167,7 +166,6 @@ class Lecture(models.Model):
     def to_json(self, nested=False):
         if self.deleted:
             print("WARNING: You are serializing DELETED lecture: %s. Please check your query" % self)
-            traceback.print_stack()
 
         cache_id = self.get_cache_key(nested)
         result_cached = cache.get(cache_id)


### PR DESCRIPTION
It solves #992.

<img width="1283" alt="image" src="https://github.com/sparcs-kaist/otlplus/assets/100757008/700e3b64-e4e5-45f9-af2b-fe66e39e8833">
